### PR TITLE
Use HTML meta tag and HTTP header to avoid leaking info through referrer

### DIFF
--- a/backend/globaleaks/handlers/base.py
+++ b/backend/globaleaks/handlers/base.py
@@ -220,6 +220,9 @@ class BaseHandler(RequestHandler):
         self.set_header("Pragma", "no-cache")
         self.set_header("Expires", "-1")
 
+        # to avoid information leakage via referrer
+        self.set_header("Content-Security-Policy", "referrer no-referrer")
+
         # to avoid Robots spidering, indexing, caching
         self.set_header("X-Robots-Tag", "noindex")
 

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width,user-scalable=no">
+    <meta name="referrer" content="never">
 
     <!-- build:css styles.css -->
     <link rel="stylesheet" href="components/bootstrap/dist/css/bootstrap.css">


### PR DESCRIPTION
Modifies server and client to fix #1068

HTML tag based on https://wiki.whatwg.org/wiki/Meta_referrer

HTTP header based on https://w3c.github.io/webappsec/specs/content-security-policy/#directive-referrer