### PR TITLE
Add client side javascript code coverage report for end to end tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,9 @@ addons:
   sauce_connect: true
 install:
     - true
+before_script:
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 script:
   - $TRAVIS_BUILD_DIR/scripts/travis.sh

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+Changes in version 2.60.114 - 2015-11-09
+    o [TODO]
+
 Changes in version 2.60.113 - 2015-10-22
     o Minor UI fixes
     o Packaging fixes

--- a/backend/globaleaks/__init__.py
+++ b/backend/globaleaks/__init__.py
@@ -8,7 +8,7 @@ import operator
 __author__ = u'Random GlobaLeaks Developers'
 __copyright__ = u'Hermes Center for Transparency and Digital Human Rights.'
 __email__ = u'info@globaleaks.org'
-__version__ = u'2.60.113'
+__version__ = u'2.60.114'
 
 DATABASE_VERSION = 24
 FIRST_DATABASE_VERSION_SUPPORTED = 11

--- a/backend/globaleaks/db/__init__.py
+++ b/backend/globaleaks/db/__init__.py
@@ -90,13 +90,6 @@ def init_db(store):
     admin = db_create_admin(store, admin_dict, GLSettings.defaults.language)
     admin.password_change_needed = False
 
-    submission_counter_dict = {
-      'key': u'submission_sequence',
-      'count': 0
-    }
-
-    store.add(models.Counter(submission_counter_dict))
-
     notification = models.Notification()
     for k in appdata_dict['templates']:
         setattr(notification, k, appdata_dict['templates'][k])

--- a/backend/globaleaks/db/migrations/update_24/__init__.py
+++ b/backend/globaleaks/db/migrations/update_24/__init__.py
@@ -385,6 +385,7 @@ class MigrationScript(MigrationBase):
             new_notification.port = 587
             new_notification.username = u'hey_you_should_change_me'
             new_notification.password = u'yes_you_really_should_change_me'
+            new_notification.source_email = u'notification@demo.globaleaks.org'
 
         self.store_new.add(new_notification)
 

--- a/backend/globaleaks/db/migrations/update_24/__init__.py
+++ b/backend/globaleaks/db/migrations/update_24/__init__.py
@@ -2,6 +2,7 @@
 
 import string
 
+from storm.expr import And, In
 from storm.locals import Int, Bool, Unicode, DateTime, JSON, Reference
 
 from globaleaks.db.migrations.update import MigrationBase
@@ -568,7 +569,7 @@ class MigrationScript(MigrationBase):
                     continue
 
                 if v.name == 'enable_whistleblower_identity':
-                    new_obj.enable_whistleblower_identity = True
+                    new_obj.enable_whistleblower_identity = False
                     continue
 
                 setattr(new_obj, v.name, getattr(old_obj, v.name))
@@ -631,7 +632,8 @@ class MigrationScript(MigrationBase):
 
         for old_obj in old_objs:
             new_obj = self.store_new.find(new_obj_model,
-                                          new_obj_model.hash == old_obj.hash).one()
+                                          And(new_obj_model.hash == old_obj.hash,
+                                              new_obj_model.type == old_obj.type)).one()
 
             if not new_obj:
                 new_obj = new_obj_model()

--- a/backend/globaleaks/handlers/rtip.py
+++ b/backend/globaleaks/handlers/rtip.py
@@ -129,9 +129,6 @@ def db_get_rtip(store, user_id, rtip_id, language):
         # If Receiver is accessing this Tip, Events related can be removed before
         # Notification is sent. This is a Twitter/Facebook -like behavior.
         store.find(EventLogs, EventLogs.receivertip_id == rtip_id).remove()
-        # Note - before the check was:
-        # store.find(EventLogs, And(EventLogs.receivertip_id == rtip_id,
-        #                          EventLogs.mail_sent == True)).remove()
 
     return serialize_rtip(store, rtip, language)
 

--- a/backend/globaleaks/handlers/submission.py
+++ b/backend/globaleaks/handlers/submission.py
@@ -30,19 +30,22 @@ from globaleaks.utils.utility import log, utc_future_date, datetime_now, datetim
 
 def db_assign_submission_progressive(store):
     counter = store.find(models.Counter, models.Counter.key == u'submission_sequence').one()
-    now = datetime_now()
-    update = counter.update_date
-    if ((now > counter.update_date) and (not((now.year == update.year) and \
-                                             (now.month == update.month) and \
-                                             (now.day == update.day)))):
-        counter.counter = 1
+    if not counter:
+        counter = models.Counter({'key': u'submission_sequence', 'counter': 1})
+        store.add(counter)
     else:
-        counter.counter += 1
+        now = datetime_now()
+        update = counter.update_date
+        if ((now > counter.update_date) and (not((now.year == update.year) and \
+                                                 (now.month == update.month) and \
+                                                 (now.day == update.day)))):
+            counter.counter = 1
+        else:
+            counter.counter += 1
 
-    counter.update_date = now
+        counter.update_date = now
 
     return counter.counter
-
 
 def _db_get_archived_fieldattr(fieldattr, language):
     return get_localized_values(fieldattr, fieldattr, models.FieldAttr.localized_keys, language)

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -4,3 +4,4 @@ app/components/
 pot/
 build/
 dest
+coverage

--- a/client/app/views/submission/form_field_input.html
+++ b/client/app/views/submission/form_field_input.html
@@ -1,4 +1,4 @@
-<div data-ng-form="f" class="submissionFieldInput">
+<div data-ng-form="f" class="submissionFieldInput"  data-ng-init="field.required = false">
   <div data-ng-switch="field.key">
     <div data-ng-switch-when="whistleblower_identity">
       <div data-ng-include="'views/submission/fields/whistleblower_identity.html'"></div>

--- a/client/bower.json
+++ b/client/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "GLClient",
-  "version": "2.60.113",
+  "version": "2.60.114",
   "homepage": "https://github.com/globaleaks/GlobaLeaks",
   "authors": [
     "Random GlobaLeaks Developers <info@globaleaks.org>"

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "chai": "3.4.1",
+    "coveralls": "^2.11.4",
     "grunt": "0.4.5",
     "grunt-angular-templates": "0.5.7",
     "grunt-bower-task": "0.4.0",
@@ -24,6 +25,7 @@
     "grunt-manifest": "0.4.4",
     "grunt-mocha-phantomjs": "2.0.0",
     "grunt-mocha-test": "0.12.7",
+    "grunt-protractor-coverage": "^0.2.15",
     "grunt-protractor-runner": "2.1.0",
     "grunt-saucelabs": "8.6.1",
     "grunt-string-replace": "1.2.0",
@@ -32,6 +34,7 @@
     "mocha-phantomjs": "4.0.1",
     "node-gettext": "0.2.14",
     "phantomjs": "1.9.18",
+    "protractor": "^2.5.1",
     "should": "7.1.1",
     "superagent": "1.4.0",
     "supertest": "1.1.0"

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Random GlobaLeaks Developers",
   "name": "GLClient",
-  "version": "2.60.113",
+  "version": "2.60.114",
   "dependencies": {
     "bower": "*"
   },

--- a/client/tests/end2end/protractor-coverage.config.js
+++ b/client/tests/end2end/protractor-coverage.config.js
@@ -1,0 +1,27 @@
+exports.config = {
+  framework: 'jasmine2',
+
+  baseUrl: 'http://127.0.0.1:8082/',
+
+  troubleshoot: true,
+  directConnect: false,
+
+  specs: [
+    'tests/end2end/test-init.js',
+    'tests/end2end/test-admin-perform-wizard.js',
+    'tests/end2end/test-admin-login.js',
+    'tests/end2end/test-admin-configure-node.js',
+    'tests/end2end/test-admin-configure-receivers.js',
+    'tests/end2end/test-admin-configure-contexts.js',
+    'tests/end2end/test-receiver-first-login.js',
+    'tests/end2end/test-globaleaks-process.js'
+  ],
+
+  capabilities: {
+    'browserName': 'firefox'
+  },
+
+  jasmineNodeOpts: {
+   isVerbose: true,
+  }
+};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+globaleaks (2.60.114) stable; urgency=medium
+
+  * New stable release
+
+ -- GlobaLeaks software signing key <info@globaleaks.org>  Mon, 09 Nov 2015 04:51:37 +0100
+
 globaleaks (2.60.113) stable; urgency=medium
 
   * New stable release

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -20,10 +20,22 @@ if [ "$GLTEST" = "unit" ]; then
   setupDependencies
   cd $TRAVIS_BUILD_DIR/backend
   coverage run setup.py test
-  coveralls || true
+
   $TRAVIS_BUILD_DIR/backend/bin/globaleaks -z travis
   sleep 5
   $TRAVIS_BUILD_DIR/client/node_modules/mocha/bin/mocha -R list $TRAVIS_BUILD_DIR/client/tests/api/test_00* --timeout 30000
+
+  echo "Running Protractor End2End locally for coverage"
+  cd $TRAVIS_BUILD_DIR/client
+  rm -fr $TRAVIS_BUILD_DIR/client/coverage
+  ./node_modules/protractor/bin/webdriver-manager update
+
+  $TRAVIS_BUILD_DIR/backend/bin/globaleaks -z travis -c -k9
+  sleep 5
+  grunt end2end-coverage
+
+  cd $TRAVIS_BUILD_DIR/backend
+  coveralls --merge=../client/coverage/coveralls.json || true
 
 elif [ "$GLTEST" = "build_and_install" ]; then
 


### PR DESCRIPTION
Here are some changes on the build and continuous integration configuration to have code coverage of the end to end client side tests and to add this information to what is sent to [coveralls](https://coveralls.io/github/globaleaks).

With these changes it's possible to see the coverage of the client side javascript code from the end to end (protractor) tests. These results are sent to coveralls together with the coverage results of the python (trial) unit tests to have a global coverage mesure.

Change CI (travis) to run client end to end tests for coverage together with unit tests on first job and to send coverage info to coveralls aggregates in one step. For that, it is necessary to generate coveralls JSON for client coverage separately.

The coverage goes down 5% only, but the coverage of the client side is around 56%, there is just a lot more python code than client javascript.

One other thing, the workaround I had to do to have the client side sources appear in [coveralls](https://coveralls.io/github/globaleaks), makes their path a little ugly. I didn't find any way of going around this with the current tools. What could be done, of course, is generate the JSON, change all file names inside it and call the API directly. I chose not to do this yet.

Please review and tell me what you think should change.