### PR TITLE
Feature/1577

### DIFF
--- a/backend/globaleaks/handlers/rtip.py
+++ b/backend/globaleaks/handlers/rtip.py
@@ -91,7 +91,7 @@ def serialize_rtip(store, rtip, language):
     ret['label'] = rtip.label
     ret['files'] = db_get_files_receiver(store, user_id, rtip.id)
     ret['total_score'] = rtip.internaltip.total_score
-    ret['enable_notifications'] = rtip.enable_notifications
+    ret['enable_notifications'] = bool(rtip.enable_notifications)
 
     return ret
 

--- a/backend/globaleaks/handlers/rtip.py
+++ b/backend/globaleaks/handlers/rtip.py
@@ -91,6 +91,7 @@ def serialize_rtip(store, rtip, language):
     ret['label'] = rtip.label
     ret['files'] = db_get_files_receiver(store, user_id, rtip.id)
     ret['total_score'] = rtip.internaltip.total_score
+    ret['enable_notifications'] = rtip.enable_notifications
 
     return ret
 
@@ -347,7 +348,7 @@ def get_identityaccessrequest_list(store, user_id, rtip_id, language):
 
 class RTipInstance(BaseHandler):
     """
-    This interface expose the Receiver Tip
+    This interface exposes the Receiver's Tip
     """
     @BaseHandler.transport_security_check('receiver')
     @BaseHandler.authenticated('receiver')
@@ -376,26 +377,27 @@ class RTipInstance(BaseHandler):
     @inlineCallbacks
     def put(self, tip_id):
         """
-        Some special operation over the Tip are handled here
+        Some special operations that manipulate a Tip are handled here
         """
         request = self.validate_message(self.request.body, requests.TipOpsDesc)
 
         if request['operation'] == 'postpone':
             yield postpone_expiration_date(self.current_user.user_id, tip_id)
-        elif request['operation'] == 'set' and \
-                (request['args']['key'] == 'label' and isinstance(request['args']['value'], unicode)):
-            set_receivertip_variable(self.current_user.user_id,
-                                     tip_id,
-                                     request['args']['key'],
-                                     request['args']['value'])
-        elif (request['args']['key'] in ['enable_two_way_comments',
-                                         'enable_two_way_messages',
-                                         'enable_attachments'] and isinstance(request['args']['value'], bool)):
-            set_internaltip_variable(self.current_user.user_id,
-                                     tip_id,
-                                     request['args']['key'],
-                                     request['args']['value'])
+        elif request['operation'] == 'set':
+            key = request['args']['key']
+            value = request['args']['value']
+            internal_var_lst = ['enable_two_way_comments', 
+                                'enable_two_way_messages', 
+                                'enable_attachments'] 
+            if key == 'label' and isinstance(value, unicode):
+                set_receivertip_variable(self.current_user.user_id, tip_id, key, value)
+            elif key == 'enable_notifications' and isinstance(value, bool):
+                set_receivertip_variable(self.current_user.user_id, tip_id, key, value)
+            elif key in internal_var_lst and isinstance(value, bool):
+                # Elements of internal_var_lst are not stored in the receiver's tip table
+                set_internaltip_variable(self.current_user.user_id, tip_id, key, value)
 
+        # TODO A 202 is returned regardless of whether or not an update was performed.
         self.set_status(202)  # Updated
         self.finish()
 

--- a/backend/globaleaks/jobs/notification_sched.py
+++ b/backend/globaleaks/jobs/notification_sched.py
@@ -120,9 +120,15 @@ class MailGenerator(object):
         self.process_mail_creation(store, data)
 
     def process_mail_creation(self, store, data):
+        receiver_id = data['receiver']['id']
+
+        # Do not spool emails if the receiver has opted out of ntfns for this tip.
+        if not data['tip']['enable_notifications']:
+          log.debug("Discarding emails for %s due to receiver's preference." % receiver_id)
+          return
+
         # https://github.com/globaleaks/GlobaLeaks/issues/798
         # TODO: the current solution is global and configurable only by the admin
-        receiver_id = data['receiver']['id']
         sent_emails = GLSettings.get_mail_counter(receiver_id)
         if sent_emails >= GLSettings.memory_copy.notification_threshold_per_hour:
             log.debug("Discarding emails for receiver %s due to threshold already exceeded for the current hour" %

--- a/backend/globaleaks/models/__init__.py
+++ b/backend/globaleaks/models/__init__.py
@@ -315,7 +315,7 @@ class ReceiverTip(Model):
 
     new = Int(default=True)
 
-    enable_notifications = Int(default=True)
+    enable_notifications = Bool(default=True)
 
     unicode_keys = ['label']
 

--- a/backend/globaleaks/tests/handlers/test_rtip.py
+++ b/backend/globaleaks/tests/handlers/test_rtip.py
@@ -133,6 +133,26 @@ class TestRTipInstance(helpers.TestHandlerWithPopulatedDB):
             yield handler.get(rtip_desc['id'])
             self.assertEqual(self.responses[0]['label'], operation['args']['value'])
 
+    @inlineCallbacks
+    def test_put_silence_notify(self):
+        rtips_desc = yield self.get_rtips()
+        for rtip_desc in rtips_desc:
+            self.responses = []
+
+            operation = {
+              'operation': 'set',
+              'args': {
+                'key': 'enable_notifications',
+                'value': False
+              }
+            }
+
+            handler = self.request(operation, role='receiver', user_id = rtip_desc['receiver_id'])
+            yield handler.put(rtip_desc['id'])
+            self.assertEqual(handler.get_status(), 202)
+
+            yield handler.get(rtip_desc['id'])
+            self.assertEqual(self.responses[0]['enable_notifications'], operation['args']['value'])
 
     @inlineCallbacks
     def test_delete_delete(self):

--- a/client/app/js/controllers/tip.js
+++ b/client/app/js/controllers/tip.js
@@ -189,6 +189,10 @@ GLClient.controller('TipCtrl',
       $scope.tip.newMessageContent = '';
     };
 
+    $scope.tip_notify = function(enable) {
+      $scope.tip.setVar('enable_notifications', enable);
+    };
+
     $scope.tip_delete = function () {
       var modalInstance = $uibModal.open({
         templateUrl: 'views/partials/tip_operation_delete.html',

--- a/client/app/views/receiver/tip.html
+++ b/client/app/views/receiver/tip.html
@@ -40,7 +40,7 @@
       <span class="glyphicon glyphicon-trash"></span>
     </span>
 
-    <span ng-if="tip.enable_notifications" id="tip-action-silence"
+    <span id="tip-action-silence" ng-if="tip.enable_notifications" 
           data-ng-click="tip_notify(false)"
           uib-popover="{{'Silence email notifications' | translate}}"
           popover-placement="top"
@@ -49,7 +49,7 @@
       <span class="glyphicon glyphicon-eye-open"></span>
     </span>
 
-    <span ng-if="tip.enable_notifications !== undefined && !tip.enable_notifications" id="tip-action-notify"
+    <span id="tip-action-notify" ng-if="tip.enable_notifications !== undefined && !tip.enable_notifications" 
           data-ng-click="tip_notify(true)"
           uib-popover="{{'Email notifications for this tip are disabled.' | translate}}"
           popover-placement="top"

--- a/client/app/views/receiver/tip.html
+++ b/client/app/views/receiver/tip.html
@@ -40,6 +40,24 @@
       <span class="glyphicon glyphicon-trash"></span>
     </span>
 
+    <span ng-if="tip.enable_notifications" id="tip-action-silence"
+          data-ng-click="tip_notify(false)"
+          uib-popover="{{'Silence email notifications' | translate}}"
+          popover-placement="top"
+          popover-trigger="mouseenter"
+          class="btn btn-default">
+      <span class="glyphicon glyphicon-eye-open"></span>
+    </span>
+
+    <span ng-if="tip.enable_notifications !== undefined && !tip.enable_notifications" id="tip-action-notify"
+          data-ng-click="tip_notify(true)"
+          uib-popover="{{'Email notifications for this tip are disabled.' | translate}}"
+          popover-placement="top"
+          popover-trigger="mouseenter"
+          class="btn btn-default alert-warning">
+      <span class="glyphicon glyphicon-eye-close"></span>
+    </span>
+
     <span id="link-reload"
           data-ng-click="reload()"
           uib-popover="{{'Refresh page' | translate}}"

--- a/client/tests/end2end/test-globaleaks-process.js
+++ b/client/tests/end2end/test-globaleaks-process.js
@@ -274,6 +274,23 @@ describe('globaLeaks process', function() {
     }
   });
 
+
+  fit('Recipient should be able to disable and renable email notifications', function() {
+    login_receiver(receiver_username, receiver_password);
+    element(by.id('tip-0')).click();
+    var silence = element(by.id('tip-action-silence'));
+    silence.click();
+    var notif = element(by.id('tip-action-notify'));
+    notif.evaluate('tip.enable_notifications').then(function(enabled) {
+      expect(enabled).toEqual(false);
+      notif.click();
+      silence.evaluate('tip.enable_notifications').then(function(enabled) {
+        expect(enabled).toEqual(true);
+        // TODO Determine if emails are actually blocked.
+      });
+    });
+  });
+
   it('Recipient should be able to all of the submissions from the tips page', function() {
     login_receiver(receiver_username, receiver_password);
     // Select the export btn on all of the tips

--- a/client/tests/end2end/test-globaleaks-process.js
+++ b/client/tests/end2end/test-globaleaks-process.js
@@ -275,7 +275,7 @@ describe('globaLeaks process', function() {
   });
 
 
-  fit('Recipient should be able to disable and renable email notifications', function() {
+  it('Recipient should be able to disable and renable email notifications', function() {
     login_receiver(receiver_username, receiver_password);
     element(by.id('tip-0')).click();
     var silence = element(by.id('tip-action-silence'));


### PR DESCRIPTION
This addresses #1577 which gives each recipient the ability to toggle notifications for individual submissions on and off.

It uses the extensibility of the `tip.setVar( )` function on the client side and the `rtip put` handler on the server to get the job done. Finally, the actual check on whether or not to actually send the mail or not occurs in `process_mail_creation`.

I believe that `process_mail_creation` needs a bit of scrutiny. The function already does many different things and while it looked like the place to put the logic. It seems like there could be a better place to intercept the mail spooling.