### PR TITLE
Remove redundant usages of request.set_status(200) and request.finish()

### DIFF
--- a/backend/globaleaks/handlers/admin/context.py
+++ b/backend/globaleaks/handlers/admin/context.py
@@ -246,8 +246,7 @@ class ContextsCollection(BaseHandler):
         """
         response = yield get_context_list(self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -269,7 +268,7 @@ class ContextsCollection(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(201) # Created
-        self.finish(response)
+        self.write(response)
 
 
 class ContextInstance(BaseHandler):
@@ -286,8 +285,7 @@ class ContextInstance(BaseHandler):
         """
         response = yield get_context(context_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -310,7 +308,7 @@ class ContextInstance(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(202) # Updated
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -325,6 +323,3 @@ class ContextInstance(BaseHandler):
         """
         yield delete_context(context_id)
         GLApiCache.invalidate()
-
-        self.set_status(200) # Ok and return no content
-        self.finish()

--- a/backend/globaleaks/handlers/admin/field.py
+++ b/backend/globaleaks/handlers/admin/field.py
@@ -426,8 +426,7 @@ class FieldTemplatesCollection(BaseHandler):
         response = yield get_fieldtemplate_list(self.request.language,
                                                 self.request.request_type)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -443,7 +442,7 @@ class FieldTemplatesCollection(BaseHandler):
         response = yield create_field(request, self.request.language, self.request.request_type)
 
         self.set_status(201)
-        self.finish(response)
+        self.write(response)
 
 
 class FieldTemplateInstance(BaseHandler):
@@ -463,8 +462,7 @@ class FieldTemplateInstance(BaseHandler):
                                    self.request.language,
                                    self.request.request_type)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -489,7 +487,7 @@ class FieldTemplateInstance(BaseHandler):
         GLApiCache.invalidate('contexts')
 
         self.set_status(202) # Updated
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -504,8 +502,6 @@ class FieldTemplateInstance(BaseHandler):
         yield delete_field(field_id)
 
         GLApiCache.invalidate('contexts')
-
-        self.set_status(200)
 
 
 class FieldCollection(BaseHandler):
@@ -535,7 +531,7 @@ class FieldCollection(BaseHandler):
         GLApiCache.invalidate('contexts')
 
         self.set_status(201)
-        self.finish(response)
+        self.write(response)
 
 
 class FieldInstance(BaseHandler):
@@ -563,8 +559,7 @@ class FieldInstance(BaseHandler):
 
         GLApiCache.invalidate('contexts')
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -590,7 +585,7 @@ class FieldInstance(BaseHandler):
         GLApiCache.invalidate('contexts')
 
         self.set_status(202) # Updated
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -606,5 +601,3 @@ class FieldInstance(BaseHandler):
         yield delete_field(field_id)
 
         GLApiCache.invalidate('contexts')
-
-        self.set_status(200)

--- a/backend/globaleaks/handlers/admin/langfiles.py
+++ b/backend/globaleaks/handlers/admin/langfiles.py
@@ -37,7 +37,6 @@ class AdminLanguageFileHandler(BaseHandler):
     @BaseHandler.authenticated('admin')
     def get(self, lang):
         self.set_status(204)
-        self.finish()
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -49,7 +48,6 @@ class AdminLanguageFileHandler(BaseHandler):
         uploaded_file = self.get_file_upload()
         if uploaded_file is None:
             self.set_status(201)
-            self.finish()
             return
 
         path = self.custom_langfile_path(lang)
@@ -67,7 +65,6 @@ class AdminLanguageFileHandler(BaseHandler):
         log.debug("Admin uploaded new lang file: %s" % dumped_file['filename'])
 
         self.set_status(201)  # Created
-        self.finish()
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -83,6 +80,3 @@ class AdminLanguageFileHandler(BaseHandler):
             raise errors.LangFileNotFound
 
         os.remove(path)
-
-        self.set_status(200)
-        self.finish()

--- a/backend/globaleaks/handlers/admin/node.py
+++ b/backend/globaleaks/handlers/admin/node.py
@@ -165,8 +165,7 @@ class NodeInstance(BaseHandler):
         Response: AdminNodeDesc
         """
         node_description = yield admin_serialize_node(self.request.language)
-        self.set_status(200)
-        self.finish(node_description)
+        self.write(node_description)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -186,4 +185,4 @@ class NodeInstance(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(202) # Updated
-        self.finish(node_description)
+        self.write(node_description)

--- a/backend/globaleaks/handlers/admin/notification.py
+++ b/backend/globaleaks/handlers/admin/notification.py
@@ -136,8 +136,7 @@ class NotificationInstance(BaseHandler):
         Errors: None (return empty configuration, at worst)
         """
         notification_desc = yield get_notification(self.request.language)
-        self.set_status(200)
-        self.finish(notification_desc)
+        self.write(notification_desc)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -156,4 +155,4 @@ class NotificationInstance(BaseHandler):
         response = yield update_notification(request, self.request.language)
 
         self.set_status(202)
-        self.finish(response)
+        self.write(response)

--- a/backend/globaleaks/handlers/admin/overview.py
+++ b/backend/globaleaks/handlers/admin/overview.py
@@ -224,8 +224,7 @@ class Tips(BaseHandler):
         """
         tips_complete_list = yield collect_tip_overview(self.request.language)
 
-        self.set_status(200)
-        self.finish(tips_complete_list)
+        self.write(tips_complete_list)
 
 
 class Users(BaseHandler):
@@ -245,8 +244,7 @@ class Users(BaseHandler):
         """
         users_complete_list = yield collect_users_overview()
 
-        self.set_status(200)
-        self.finish(users_complete_list)
+        self.write(users_complete_list)
 
 
 class Files(BaseHandler):
@@ -269,5 +267,4 @@ class Files(BaseHandler):
 
         file_complete_list = yield collect_files_overview()
 
-        self.set_status(200)
-        self.finish(file_complete_list)
+        self.write(file_complete_list)

--- a/backend/globaleaks/handlers/admin/questionnaire.py
+++ b/backend/globaleaks/handlers/admin/questionnaire.py
@@ -182,8 +182,7 @@ class QuestionnairesCollection(BaseHandler):
         """
         response = yield get_questionnaire_list(self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -205,7 +204,7 @@ class QuestionnairesCollection(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(201) # Created
-        self.finish(response)
+        self.write(response)
 
 
 class QuestionnaireInstance(BaseHandler):
@@ -222,8 +221,7 @@ class QuestionnaireInstance(BaseHandler):
         """
         response = yield get_questionnaire(questionnaire_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -246,7 +244,7 @@ class QuestionnaireInstance(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(202) # Updated
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -261,6 +259,3 @@ class QuestionnaireInstance(BaseHandler):
         """
         yield delete_questionnaire(questionnaire_id)
         GLApiCache.invalidate()
-
-        self.set_status(200) # Ok and return no content
-        self.finish()

--- a/backend/globaleaks/handlers/admin/receiver.py
+++ b/backend/globaleaks/handlers/admin/receiver.py
@@ -121,8 +121,7 @@ class ReceiversCollection(BaseHandler):
         """
         response = yield get_receiver_list(self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
 
 class ReceiverInstance(BaseHandler):
@@ -139,8 +138,7 @@ class ReceiverInstance(BaseHandler):
         """
         response = yield get_receiver(receiver_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -160,4 +158,4 @@ class ReceiverInstance(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(201)
-        self.finish(response)
+        self.write(response)

--- a/backend/globaleaks/handlers/admin/shorturl.py
+++ b/backend/globaleaks/handlers/admin/shorturl.py
@@ -53,8 +53,7 @@ class ShortURLCollection(BaseHandler):
         """
         response = yield get_shorturl_list()
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -68,7 +67,7 @@ class ShortURLCollection(BaseHandler):
         response = yield create_shorturl(request)
 
         self.set_status(201) # Created
-        self.finish(response)
+        self.write(response)
 
 
 class ShortURLInstance(BaseHandler):
@@ -80,6 +79,3 @@ class ShortURLInstance(BaseHandler):
         Delete the specified shorturl.
         """
         yield delete_shorturl(shorturl_id)
-
-        self.set_status(200) # OK and return not content
-        self.finish()

--- a/backend/globaleaks/handlers/admin/staticfiles.py
+++ b/backend/globaleaks/handlers/admin/staticfiles.py
@@ -121,7 +121,6 @@ class StaticFileInstance(BaseHandler):
         uploaded_file = self.get_file_upload()
         if uploaded_file is None:
             self.set_status(201)
-            self.finish()
             return
 
         if filename == 'upload':
@@ -138,7 +137,6 @@ class StaticFileInstance(BaseHandler):
 
         log.debug('Admin uploaded new static file: %s' % dumped_file['filename'])
         self.set_status(201)
-        self.finish()
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -153,8 +151,6 @@ class StaticFileInstance(BaseHandler):
             raise errors.StaticFileNotFound
 
         os.remove(path)
-        self.set_status(200)
-        self.finish()
 
 
 class StaticFileList(BaseHandler):
@@ -164,8 +160,7 @@ class StaticFileList(BaseHandler):
         """
         Return the list of static files, with few filesystem info
         """
-        self.set_status(200)
-        self.finish(get_stored_files())
+        self.write(get_stored_files())
 
 
 class NodeLogoInstance(StaticFileInstance):
@@ -176,7 +171,6 @@ class NodeLogoInstance(StaticFileInstance):
         uploaded_file = self.get_file_upload()
         if uploaded_file is None:
             self.set_status(201)
-            self.finish()
             return
 
         try:
@@ -190,7 +184,6 @@ class NodeLogoInstance(StaticFileInstance):
         GLApiCache.invalidate()
 
         self.set_status(201)
-        self.finish()
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -199,9 +192,6 @@ class NodeLogoInstance(StaticFileInstance):
         yield del_node_logo()
 
         GLApiCache.invalidate()
-
-        self.set_status(200)
-        self.finish()
 
 
 class UserImgInstance(StaticFileInstance):
@@ -214,7 +204,6 @@ class UserImgInstance(StaticFileInstance):
         uploaded_file = self.get_file_upload()
         if uploaded_file is None:
             self.set_status(201)
-            self.finish()
             return
 
         try:
@@ -228,7 +217,6 @@ class UserImgInstance(StaticFileInstance):
         GLApiCache.invalidate()
 
         self.set_status(201)
-        self.finish()
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -237,9 +225,6 @@ class UserImgInstance(StaticFileInstance):
         yield del_model_img(self.model, obj_id)
 
         GLApiCache.invalidate()
-
-        self.set_status(200)
-        self.finish()
 
 
 class ContextImgInstance(UserImgInstance):

--- a/backend/globaleaks/handlers/admin/statistics.py
+++ b/backend/globaleaks/handlers/admin/statistics.py
@@ -180,7 +180,7 @@ class AnomalyCollection(BaseHandler):
     @inlineCallbacks
     def get(self):
         anomaly_history = yield get_anomaly_history(limit=20)
-        self.finish(anomaly_history)
+        self.write(anomaly_history)
 
     @BaseHandler.transport_security_check("admin")
     @BaseHandler.authenticated("admin")
@@ -188,7 +188,7 @@ class AnomalyCollection(BaseHandler):
     def delete(self):
         log.info("Received anomalies history delete command")
         yield delete_anomaly_history()
-        self.finish([])
+        self.write([])
 
 
 class StatsCollection(BaseHandler):
@@ -210,7 +210,7 @@ class StatsCollection(BaseHandler):
 
         ret = yield get_stats(week_delta)
 
-        self.finish(ret)
+        self.write(ret)
 
     @BaseHandler.transport_security_check("admin")
     @BaseHandler.authenticated("admin")
@@ -218,7 +218,7 @@ class StatsCollection(BaseHandler):
     def delete(self):
         log.info("Received statistic history delete command")
         yield delete_weekstats_history()
-        self.finish([])
+        self.write([])
 
 
 class RecentEventsCollection(BaseHandler):
@@ -249,6 +249,6 @@ class RecentEventsCollection(BaseHandler):
         templist.sort(key=operator.itemgetter('id'))
 
         if kind == 'details':
-            self.finish(templist)
+            self.write(templist)
         else:  # kind == 'summary':
-            self.finish(self.get_summary(templist))
+            self.write(self.get_summary(templist))

--- a/backend/globaleaks/handlers/admin/step.py
+++ b/backend/globaleaks/handlers/admin/step.py
@@ -136,7 +136,7 @@ class StepCollection(BaseHandler):
         GLApiCache.invalidate('contexts')
 
         self.set_status(201)
-        self.finish(response)
+        self.write(response)
 
 
 class StepInstance(BaseHandler):
@@ -160,8 +160,7 @@ class StepInstance(BaseHandler):
         """
         response = yield get_step(step_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
 
     @BaseHandler.transport_security_check('admin')
@@ -185,7 +184,7 @@ class StepInstance(BaseHandler):
         GLApiCache.invalidate('contexts')
 
         self.set_status(202) # Updated
-        self.finish(response)
+        self.write(response)
 
 
     @BaseHandler.transport_security_check('admin')
@@ -202,5 +201,3 @@ class StepInstance(BaseHandler):
         yield delete_step(step_id)
 
         GLApiCache.invalidate('contexts')
-
-        self.set_status(200)

--- a/backend/globaleaks/handlers/admin/user.py
+++ b/backend/globaleaks/handlers/admin/user.py
@@ -222,8 +222,7 @@ class UsersCollection(BaseHandler):
         """
         response = yield get_user_list(self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -249,7 +248,7 @@ class UsersCollection(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(201) # Created
-        self.finish(response)
+        self.write(response)
 
 
 class UserInstance(BaseHandler):
@@ -266,8 +265,7 @@ class UserInstance(BaseHandler):
         """
         response = yield get_user(user_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(response)
+        self.write(response)
 
     @BaseHandler.transport_security_check('admin')
     @BaseHandler.authenticated('admin')
@@ -287,7 +285,7 @@ class UserInstance(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(201)
-        self.finish(response)
+        self.write(response)
 
     @inlineCallbacks
     @BaseHandler.transport_security_check('admin')
@@ -304,6 +302,3 @@ class UserInstance(BaseHandler):
         yield delete_user(user_id)
 
         GLApiCache.invalidate()
-
-        self.set_status(200) # OK and return not content
-        self.finish()

--- a/backend/globaleaks/handlers/authentication.py
+++ b/backend/globaleaks/handlers/authentication.py
@@ -161,9 +161,6 @@ class AuthenticationHandler(BaseHandler):
             except KeyError:
                 raise errors.NotAuthenticated
 
-        self.set_status(200)
-        self.finish()
-
 
 class ReceiptAuthHandler(AuthenticationHandler):
     handler_exec_time_threshold = 60

--- a/backend/globaleaks/handlers/base.py
+++ b/backend/globaleaks/handlers/base.py
@@ -516,7 +516,7 @@ class BaseHandler(RequestHandler):
                 error_dict.update({'arguments': []})
 
             self.set_status(status_code)
-            self.finish(error_dict)
+            self.write(error_dict)
         else:
             RequestHandler.write_error(self, status_code, **kw)
 
@@ -781,5 +781,4 @@ class TimingStatsHandler(BaseHandler):
                                          measure['uri'],
                                          measure['start_time'],
                                          measure['run_time'])
-        self.set_status(200)
-        self.finish(csv)
+        self.write(csv)

--- a/backend/globaleaks/handlers/custodian.py
+++ b/backend/globaleaks/handlers/custodian.py
@@ -80,8 +80,7 @@ class IdentityAccessRequestInstance(BaseHandler):
         identityaccessrequest = yield get_identityaccessrequest(identityaccessrequest_id,
                                                                 self.request.language)
 
-        self.set_status(200)
-        self.finish(identityaccessrequest)
+        self.write(identityaccessrequest)
 
 
     @BaseHandler.transport_security_check('custodian')
@@ -101,8 +100,7 @@ class IdentityAccessRequestInstance(BaseHandler):
                                                                    request,
                                                                    self.request.language)
 
-        self.set_status(200)
-        self.finish(identityaccessrequest)
+        self.write(identityaccessrequest)
 
 
 class IdentityAccessRequestsCollection(BaseHandler):
@@ -121,5 +119,4 @@ class IdentityAccessRequestsCollection(BaseHandler):
         """
         answer = yield get_identityaccessrequest_list(self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)

--- a/backend/globaleaks/handlers/exception.py
+++ b/backend/globaleaks/handlers/exception.py
@@ -32,5 +32,4 @@ class ExceptionHandler(BaseHandler):
             log.debug("Received client exception and notified to exception email")
 
         self.set_status(201)  # Created
-        self.finish()
 

--- a/backend/globaleaks/handlers/export.py
+++ b/backend/globaleaks/handlers/export.py
@@ -74,13 +74,9 @@ class ExportHandler(BaseHandler):
     def post(self, rtip_id):
         tip_export = yield get_tip_export(self.current_user.user_id, rtip_id, self.request.language)
 
-        self.set_status(200)
-
         self.set_header('X-Download-Options', 'noopen')
         self.set_header('Content-Type', 'application/octet-stream')
         self.set_header('Content-Disposition', 'attachment; filename=\"%s.zip\"' % tip_export['tip']['sequence_number'])
 
         for data in ZipStream(tip_export['files']):
             self.write(data)
-
-        self.finish()

--- a/backend/globaleaks/handlers/files.py
+++ b/backend/globaleaks/handlers/files.py
@@ -175,7 +175,6 @@ class FileAdd(BaseHandler):
         yield self.handle_file_append(itip_id)
 
         self.set_status(201)  # Created
-        self.finish()
 
 
 class FileInstance(BaseHandler):
@@ -224,7 +223,6 @@ class FileInstance(BaseHandler):
         yield self.handle_file_upload(token_id)
 
         self.set_status(201)  # Created
-        self.finish()
 
 
 @transact
@@ -260,7 +258,6 @@ class Download(BaseHandler):
         filelocation = os.path.join(GLSettings.submission_path, rfile['path'])
 
         if os.path.exists(filelocation):
-            self.set_status(200)
             self.set_header('X-Download-Options', 'noopen')
             self.set_header('Content-Type', 'application/octet-stream')
             self.set_header('Content-Length', rfile['size'])
@@ -268,5 +265,3 @@ class Download(BaseHandler):
             self.write_file(filelocation)
         else:
             self.set_status(404)
-
-        self.finish()

--- a/backend/globaleaks/handlers/node.py
+++ b/backend/globaleaks/handlers/node.py
@@ -340,7 +340,7 @@ class NodeInstance(BaseHandler):
         ret['custom_homepage'] = os.path.isfile(os.path.join(GLSettings.static_path,
                                                              "custom_homepage.html"))
 
-        self.finish(ret)
+        self.write(ret)
 
 
 class AhmiaDescriptionHandler(BaseHandler):
@@ -358,10 +358,9 @@ class AhmiaDescriptionHandler(BaseHandler):
             ret = yield GLApiCache.get('ahmia', self.request.language,
                                        serialize_ahmia, self.request.language)
 
-            self.finish(ret)
+            self.write(ret)
         else:  # in case of disabled option we return 404
             self.set_status(404)
-            self.finish()
 
 
 class RobotstxtHandler(BaseHandler):
@@ -382,8 +381,6 @@ class RobotstxtHandler(BaseHandler):
         else:
             self.write("User-agent: *\nDisallow: /")
 
-        self.finish()
-
 
 class ContextsCollection(BaseHandler):
     @BaseHandler.transport_security_check("unauth")
@@ -395,7 +392,7 @@ class ContextsCollection(BaseHandler):
         """
         ret = yield GLApiCache.get('contexts', self.request.language,
                                    get_public_context_list, self.request.language)
-        self.finish(ret)
+        self.write(ret)
 
 
 class ReceiversCollection(BaseHandler):
@@ -408,4 +405,4 @@ class ReceiversCollection(BaseHandler):
         """
         ret = yield GLApiCache.get('receivers', self.request.language,
                                    get_public_receiver_list, self.request.language)
-        self.finish(ret)
+        self.write(ret)

--- a/backend/globaleaks/handlers/receiver.py
+++ b/backend/globaleaks/handlers/receiver.py
@@ -140,8 +140,7 @@ class ReceiverInstance(BaseHandler):
         receiver_status = yield get_receiver_settings(self.current_user.user_id,
                                                       self.request.language)
 
-        self.set_status(200)
-        self.finish(receiver_status)
+        self.write(receiver_status)
 
 
     @BaseHandler.transport_security_check('receiver')
@@ -162,8 +161,7 @@ class ReceiverInstance(BaseHandler):
 
         GLApiCache.invalidate('receivers')
 
-        self.set_status(200)
-        self.finish(receiver_status)
+        self.write(receiver_status)
 
 
 class TipsCollection(BaseHandler):
@@ -182,8 +180,7 @@ class TipsCollection(BaseHandler):
         answer = yield get_receivertip_list(self.current_user.user_id,
                                             self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
 
 class TipsOperations(BaseHandler):
@@ -206,6 +203,3 @@ class TipsOperations(BaseHandler):
             raise errors.ForbiddenOperation
 
         yield perform_tips_operation(self.current_user.user_id, request['operation'], request['rtips'])
-
-        self.set_status(200)
-        self.finish()

--- a/backend/globaleaks/handlers/rtip.py
+++ b/backend/globaleaks/handlers/rtip.py
@@ -369,8 +369,7 @@ class RTipInstance(BaseHandler):
 
         answer = yield get_rtip(self.current_user.user_id, tip_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
     @BaseHandler.transport_security_check('receiver')
     @BaseHandler.authenticated('receiver')
@@ -399,7 +398,6 @@ class RTipInstance(BaseHandler):
 
         # TODO A 202 is returned regardless of whether or not an update was performed.
         self.set_status(202)  # Updated
-        self.finish()
 
     @BaseHandler.transport_security_check('receiver')
     @BaseHandler.authenticated('receiver')
@@ -412,9 +410,6 @@ class RTipInstance(BaseHandler):
         delete: remove the Internaltip and all the associated data
         """
         yield delete_rtip(self.current_user.user_id, tip_id)
-
-        self.set_status(200)  # Success
-        self.finish()
 
 
 class RTipCommentCollection(BaseHandler):
@@ -435,8 +430,7 @@ class RTipCommentCollection(BaseHandler):
         """
         comment_list = yield get_comment_list(self.current_user.user_id, tip_id)
 
-        self.set_status(200)
-        self.finish(comment_list)
+        self.write(comment_list)
 
     @BaseHandler.transport_security_check('receiver')
     @BaseHandler.authenticated('receiver')
@@ -452,7 +446,7 @@ class RTipCommentCollection(BaseHandler):
         answer = yield create_comment(self.current_user.user_id, tip_id, request)
 
         self.set_status(201)  # Created
-        self.finish(answer)
+        self.write(answer)
 
 
 class RTipReceiversCollection(BaseHandler):
@@ -471,8 +465,7 @@ class RTipReceiversCollection(BaseHandler):
         """
         answer = yield get_receiver_list(self.current_user.user_id, rtip_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
 
 class ReceiverMsgCollection(BaseHandler):
@@ -485,8 +478,7 @@ class ReceiverMsgCollection(BaseHandler):
     def get(self, tip_id):
         answer = yield get_message_list(self.current_user.user_id, tip_id)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
     @BaseHandler.transport_security_check('receiver')
     @BaseHandler.authenticated('receiver')
@@ -502,7 +494,7 @@ class ReceiverMsgCollection(BaseHandler):
         message = yield create_message(self.current_user.user_id, tip_id, request)
 
         self.set_status(201)  # Created
-        self.finish(message)
+        self.write(message)
 
 
 class IdentityAccessRequestsCollection(BaseHandler):
@@ -523,8 +515,7 @@ class IdentityAccessRequestsCollection(BaseHandler):
                                                       tip_id,
                                                       self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
     @BaseHandler.transport_security_check('receiver')
     @BaseHandler.authenticated('receiver')
@@ -543,4 +534,4 @@ class IdentityAccessRequestsCollection(BaseHandler):
                                                                    self.request.language)
 
         self.set_status(201)
-        self.finish(identityaccessrequest)
+        self.write(identityaccessrequest)

--- a/backend/globaleaks/handlers/submission.py
+++ b/backend/globaleaks/handlers/submission.py
@@ -450,4 +450,4 @@ class SubmissionInstance(BaseHandler):
                                              self.check_tor2web(),
                                              self.request.language)
         self.set_status(202)  # Updated, also if submission if effectively created (201)
-        self.finish(submission)
+        self.write(submission)

--- a/backend/globaleaks/handlers/token.py
+++ b/backend/globaleaks/handlers/token.py
@@ -40,7 +40,7 @@ class TokenCreate(BaseHandler):
         token = Token(request['type'])
 
         self.set_status(201) # Created
-        self.finish(token.serialize())
+        self.write(token.serialize())
 
 
 class TokenInstance(BaseHandler):
@@ -60,4 +60,4 @@ class TokenInstance(BaseHandler):
         token.update(request)
 
         self.set_status(202) # Updated
-        self.finish(token.serialize())
+        self.write(token.serialize())

--- a/backend/globaleaks/handlers/user.py
+++ b/backend/globaleaks/handlers/user.py
@@ -170,8 +170,7 @@ class UserInstance(BaseHandler):
         user_status = yield get_user_settings(self.current_user.user_id,
                                               self.request.language)
 
-        self.set_status(200)
-        self.finish(user_status)
+        self.write(user_status)
 
 
     @BaseHandler.authenticated('*')
@@ -188,5 +187,4 @@ class UserInstance(BaseHandler):
         user_status = yield update_user_settings(self.current_user.user_id,
                                                  request, self.request.language)
 
-        self.set_status(200)
-        self.finish(user_status)
+        self.write(user_status)

--- a/backend/globaleaks/handlers/wbtip.py
+++ b/backend/globaleaks/handlers/wbtip.py
@@ -163,8 +163,7 @@ class WBTipInstance(BaseHandler):
 
         answer = yield get_wbtip(self.current_user.user_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
 
 class WBTipCommentCollection(BaseHandler):
@@ -184,8 +183,7 @@ class WBTipCommentCollection(BaseHandler):
         """
         wb_comment_list = yield get_comment_list(self.current_user.user_id)
 
-        self.set_status(200)
-        self.finish(wb_comment_list)
+        self.write(wb_comment_list)
 
     @BaseHandler.transport_security_check('whistleblower')
     @BaseHandler.authenticated('whistleblower')
@@ -201,7 +199,7 @@ class WBTipCommentCollection(BaseHandler):
         answer = yield create_comment(self.current_user.user_id, request)
 
         self.set_status(201)  # Created
-        self.finish(answer)
+        self.write(answer)
 
 
 class WBTipReceiversCollection(BaseHandler):
@@ -220,8 +218,7 @@ class WBTipReceiversCollection(BaseHandler):
         """
         answer = yield get_receiver_list(self.current_user.user_id, self.request.language)
 
-        self.set_status(200)
-        self.finish(answer)
+        self.write(answer)
 
 
 class WBTipMessageCollection(BaseHandler):
@@ -238,8 +235,7 @@ class WBTipMessageCollection(BaseHandler):
     def get(self, receiver_id):
         messages = yield get_message_list(self.current_user.user_id, receiver_id)
 
-        self.set_status(200)
-        self.finish(messages)
+        self.write(messages)
 
     @BaseHandler.transport_security_check('whistleblower')
     @BaseHandler.authenticated('whistleblower')
@@ -250,7 +246,7 @@ class WBTipMessageCollection(BaseHandler):
         message = yield create_message(self.current_user.user_id, receiver_id, request)
 
         self.set_status(201)  # Created
-        self.finish(message)
+        self.write(message)
 
 
 class WBTipIdentityHandler(BaseHandler):
@@ -289,4 +285,3 @@ class WBTipIdentityHandler(BaseHandler):
         yield update_identity_information(request['identity_field_id'], request['identity_field_answers'], self.request.language)
 
         self.set_status(202)  # Updated
-        self.finish()

--- a/backend/globaleaks/handlers/wizard.py
+++ b/backend/globaleaks/handlers/wizard.py
@@ -71,4 +71,3 @@ class FirstSetup(BaseHandler):
         GLApiCache.invalidate()
 
         self.set_status(201)  # Created
-        self.finish()


### PR DESCRIPTION
This pull requests apply the following changes to all the handlers of the application:

- remove redundant self.finish() usages.
- replace self.finish(payload) with self.write(payload)
- remove redundant self.set_status(200)

@NSkelsey would you please check if this is ok for you?