### PR TITLE
Refactor build and init to exclude pyc files from packages and the file system

### DIFF
--- a/backend/bin/globaleaks
+++ b/backend/bin/globaleaks
@@ -7,6 +7,9 @@ reload(sys)
 sys.setdefaultencoding('utf8')
 sys.excepthook = None
 
+# avoid to write bytecode files at runtime
+sys.dont_write_bytecode = True
+
 import os
 import random
 import re

--- a/debian/globaleaks.init
+++ b/debian/globaleaks.init
@@ -237,8 +237,6 @@ do_start()
 
     if [ "${APPARMOR_SANDBOXING}" -eq "1" ]; then
         APPARMOR_STARTED=0
-	# bytecode will not be written to .pyc files with app-armor enabled
-        export PYTHONDONTWRITEBYTECODE=1
 
         log_action_begin_msg "Enabling GlobaLeaks Apparmor Sandboxing"
 

--- a/debian/globaleaks.init
+++ b/debian/globaleaks.init
@@ -237,8 +237,8 @@ do_start()
 
     if [ "${APPARMOR_SANDBOXING}" -eq "1" ]; then
         APPARMOR_STARTED=0
-        # Prevent the creation of pyc files to simplify app-armor
-        PYTHONDONTWRITEBYTECODE=1
+	# bytecode will not be written to .pyc files with app-armor enabled
+        export PYTHONDONTWRITEBYTECODE=1
 
         log_action_begin_msg "Enabling GlobaLeaks Apparmor Sandboxing"
 

--- a/debian/globaleaks.init
+++ b/debian/globaleaks.init
@@ -237,6 +237,8 @@ do_start()
 
     if [ "${APPARMOR_SANDBOXING}" -eq "1" ]; then
         APPARMOR_STARTED=0
+        # Prevent the creation of pyc files to simplify app-armor
+        PYTHONDONTWRITEBYTECODE=1
 
         log_action_begin_msg "Enabling GlobaLeaks Apparmor Sandboxing"
 

--- a/debian/globaleaks.postinst
+++ b/debian/globaleaks.postinst
@@ -32,6 +32,8 @@ if [ $PIP_NEEDED -eq 1 ]; then
   pip install -r /usr/share/globaleaks/requirements.txt
 fi
 
+python -c 'import compileall; compileall.compile_dir("/usr/lib/python2.7/dist-packages/globaleaks/")'
+
 # simple check to ensure to run the below commands once at the first install.
 if ! id -u globaleaks >/dev/null 2>&1; then
   useradd globaleaks -b /var/globaleaks/ -s /bin/false

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,9 @@
 #!/usr/bin/make -f
+#export DH_VERBOSE=1
 
 export PYBUILD_NAME=globaleaks
 export PYBUILD_DISABLE=test
+export PYBUILD_INSTALL_ARGS=--no-compile
 
 %:
 	dh $@ --with python2 --buildsystem=pybuild --sourcedirectory=backend/


### PR DESCRIPTION
The newer versions of lintian consider shipping pyc files a [security issue](https://lintian.debian.org/tags/package-installs-python-bytecode.html). Currently globaleaks ships with all of its pyc files inside.

```bash
> lintian globaleaks_2.65.1_all.deb
E: globaleaks: package-installs-python-bytecode usr/lib/python2.7/dist-packages/globaleaks/__init__.pyc
E: globaleaks: package-installs-python-bytecode ... use --no-tag-display-limit to see all (or pipe to a file/program)
```

Using `PYTHONDONTWRITEBYTECODE` when app-armor is initialized preserves the read only rule for the python module directories. 

The negative is that this is a performance hit when using app armor, but how large of a performance hit is unclear. My intuition here is that the cost comes in more memory usage (to store the byte code) and at startup time (which is basically nothing).