### PR TITLE
Feature/1949

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -100,7 +100,7 @@ Changes in version 2.65.11 - 2017-01-12
     - https://github.com/globaleaks/GlobaLeaks/issues/1771
     - https://github.com/globaleaks/GlobaLeaks/issues/1868
 
-Changes in version 2.65.10 -2016-12-13
+Changes in version 2.65.10 - 2016-12-13
     o Apply minor fixes
 
 Changes in version 2.65.9 - 2016-12-08
@@ -1323,12 +1323,12 @@ Changes in version 2.30 - 2013-12-05
       - https://github.com/globaleaks/GlobaLeaks/issues/708
       - https://github.com/globaleaks/GlobaLeaks/issues/709
 
-Changes in version 2.29
+Changes in version 2.29 - 2013-12-05
     o updated to Angular 1.2.0, js codebase reduced (~700~ -> ~400k)
     o implemented UI to view/delete custom uploaded files.
     o added authentication over file download and collection download
 
-Changes in version 2.28
+Changes in version 2.28 - 2013-11-05
     o added new translations (Serbian, Serbian@latin, German Czech)
 
     The following is the comprehensive list of closed tickets:
@@ -1371,24 +1371,24 @@ Changes in version 2.28
       - https://github.com/globaleaks/GlobaLeaks/issues/614
       - https://github.com/globaleaks/GlobaLeaks/issues/598
 
-Changes in version 2.26
+Changes in version 2.26 - 2013-09-09
     The following is the comprehensive list of closed tickets:
       - https://github.com/globaleaks/GlobaLeaks/issues/166
       - https://github.com/globaleaks/GlobaLeaks/issues/605
 
-Changes in version 2.25
+Changes in version 2.25 - 2013-09-08
     The following is the comprehensive list of closed tickets:
       - https://github.com/globaleaks/GlobaLeaks/issues/600
       - https://github.com/globaleaks/GlobaLeaks/issues/606
 
-Changes in version 2.24.15
+Changes in version 2.24.15 - 2013-09-08
     The following is the comprehensive list of closed tickets:
       - https://github.com/globaleaks/GlobaLeaks/issues/572
       - https://github.com/globaleaks/GlobaLeaks/issues/571
       - https://github.com/globaleaks/GlobaLeaks/issues/592
       - https://github.com/globaleaks/GlobaLeaks/issues/575
 
-Changes in version 2.24.13
+Changes in version 2.24.13 - 2013-09-08
     The following is the comprehensive list of closed tickets:
       - https://github.com/globaleaks/GlobaLeaks/issues/565
       - https://github.com/globaleaks/GlobaLeaks/issues/561
@@ -1399,7 +1399,7 @@ Changes in version 2.24.13
       - https://github.com/globaleaks/GlobaLeaks/issues/581
       - https://github.com/globaleaks/GlobaLeaks/issues/589
 
-Changes in version 2.24.10
+Changes in version 2.24.10 - 2013-08-30
     The following is the comprehensive list of closed tickets:
       - https://github.com/globaleaks/GlobaLeaks/issues/512
       - https://github.com/globaleaks/GlobaLeaks/issues/510
@@ -1414,7 +1414,7 @@ Changes in version 2.24.10
       - https://github.com/globaleaks/GlobaLeaks/issues/548
       - https://github.com/globaleaks/GlobaLeaks/issues/558
 
-Changes in version 2.24.9
+Changes in version 2.24.9 - 2013-08-18
     The following is the comprehensive list of closed tickets:
       - https://github.com/globaleaks/GlobaLeaks/issues/514
       - https://github.com/globaleaks/GlobaLeaks/issues/498
@@ -1425,7 +1425,7 @@ Changes in version 2.24.9
       - https://github.com/globaleaks/GlobaLeaks/issues/491
       - https://github.com/globaleaks/GlobaLeaks/issues/316
 
-Changes in version 2.24.3
+Changes in version 2.24.3 - 2013-08-14
     o updated translations
 
     The following is the comprehensive list of closed tickets:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,7 +10,7 @@ Changes in version 2.76.2 - 2017-04-01
       shown when javascript is disabled
     o Optimize loading reducing public API get
 
-Changes in version 2.67.1 - 2017-03-17
+Changes in version 2.67.1 - 2017-03-17 - alert:notice
     o Start (restart) apparmor upon globaleaks install
 
 Changes in version 2.67.0 - 2017-03-17

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,10 +10,10 @@ Changes in version 2.76.2 - 2017-04-01
       shown when javascript is disabled
     o Optimize loading reducing public API get
 
-Changes in version 2.67.1 - 2017-03-17 - alert:notice
+Changes in version 2.67.1 - 2017-03-17
     o Start (restart) apparmor upon globaleaks install
 
-Changes in version 2.67.0 - 2017-03-17
+Changes in version 2.67.0 - 2017-03-17 - alert:notice
     o Add Ubuntu Xenial 16.04 support
     o Add (readd) Bulgarian support thanks to volunteers translations
 

--- a/client/Gruntfile.js
+++ b/client/Gruntfile.js
@@ -797,17 +797,20 @@ module.exports = function(grunt) {
       for (var i = 0; i < lines.length; i++) {
         var l = lines[i];
         // Format of the first line of every new release is:
-        // Changes in version 2.76.4 - 2017-04-12
+        // Changes in version 2.76.4 - 2017-04-12 - alert:notice
         if (/^(Changes in version)/.test(l)) {
-            obj = {};
-            // Matches version and date
-            var res = l.match(/(\d+\.\d+(\.\d+)?) - (\d{4}-\d{2}-\d{2})$/);
-            obj.version = res[1];
-            obj.date = res[3];
-            obj.txt = l
-            chnglog.push(obj);
+          obj = {};
+          // Matches version and date
+          var res = l.match(/(\d+\.\d+(\.\d+)?) - (\d{4}-\d{2}-\d{2})/);
+          obj.version = res[1];
+          obj.date = res[3];
+          obj.txt = l
+          if (/- alert\:notice$/.test(l)) {
+            obj.alert = true;
+          }
+          chnglog.push(obj);
         } else {
-            obj.txt = obj.txt + '\n' + l;
+          obj.txt = obj.txt + '\n' + l;
         }
       }
       // Intentionally drop the first release because does not conform to the format.

--- a/client/Gruntfile.js
+++ b/client/Gruntfile.js
@@ -782,15 +782,52 @@ module.exports = function(grunt) {
 
   });
 
+
+  // Processes misc files included in the GlobaLeaks repository that need to be
+  // included as data like the license and changelog
+  grunt.registerTask('includeExternalFiles', function() {
+      var cnt = grunt.file.read('../LICENSE');
+      fs.writeFileSync('tmp/data/license.txt', cnt)
+
+      cnt = grunt.file.read('../CHANGELOG');
+      var lines = cnt.split("\n"),
+          chnglog = [],
+          obj;
+
+      for (var i = 0; i < lines.length; i++) {
+        var l = lines[i];
+        // Format of the first line of every new release is:
+        // Changes in version 2.76.4 - 2017-04-12
+        if (/^(Changes in version)/.test(l)) {
+            obj = {};
+            // Matches version and date
+            var res = l.match(/(\d+\.\d+(\.\d+)?) - (\d{4}-\d{2}-\d{2})$/);
+            obj.version = res[1];
+            obj.date = res[3];
+            obj.txt = l
+            chnglog.push(obj);
+        } else {
+            obj.txt = obj.txt + '\n' + l;
+        }
+      }
+      // Intentionally drop the first release because does not conform to the format.
+
+      // Using object here due to issues with exporting raw lists via json
+      var output = JSON.stringify({'v': chnglog});
+      fs.writeFileSync('tmp/data/changelog.json', output);
+
+      console.log('Copied misc files into ./tmp');
+  });
+
+
   // Run this task to push translations on transifex
   grunt.registerTask('pushTranslationsSource', ['confirm', '☠☠☠pushTranslationsSource☠☠☠']);
 
   // Run this task to fetch translations from transifex and create application files
   grunt.registerTask('updateTranslations', ['fetchTranslations', 'makeAppData']);
-
   // Run this to build your app. You should have run updateTranslations before you do so, if you have changed something in your translations.
   grunt.registerTask('build',
-    ['clean', 'copy:sources', 'copy:build', 'ngtemplates', 'useminPrepare', 'concat', 'usemin', 'string-replace', 'cleanupWorkingDirectory']);
+    ['clean', 'copy:sources', 'copy:build', 'includeExternalFiles', 'ngtemplates', 'useminPrepare', 'concat', 'usemin', 'string-replace', 'cleanupWorkingDirectory']);
 
   grunt.registerTask('generateCoverallsJson', function() {
     var done = this.async();

--- a/client/app/js/app.js
+++ b/client/app/js/app.js
@@ -200,6 +200,7 @@ var GLClient = angular.module('GLClient', [
         header_subtitle: 'Landing page',
         resolve: {
           access: requireAuth('admin'),
+          changelog: ['ChangeLogRes', function(ChangeLogRes) { return ChangeLogRes; }],
         }
       }).
       when('/admin/content', {

--- a/client/app/js/app.js
+++ b/client/app/js/app.js
@@ -197,7 +197,7 @@ var GLClient = angular.module('GLClient', [
         templateUrl: 'views/admin/landing.html',
         controller: 'AdminCtrl',
         header_title: 'Administration interface',
-        header_subtitle: 'Landing page',
+        header_subtitle: 'Home page',
         resolve: {
           access: requireAuth('admin'),
           changelog: ['ChangeLogRes', function(ChangeLogRes) { return ChangeLogRes; }],

--- a/client/app/js/controllers/admin/main.js
+++ b/client/app/js/controllers/admin/main.js
@@ -213,6 +213,29 @@ controller('AdminGeneralSettingsCtrl', ['$scope', '$filter', '$http', 'StaticFil
 
   $scope.update_static_files();
 }]).
+controller('AdminAboutCtrl', ['$scope', 'StaticFileResource', function($scope, StaticFileResource) {
+  // NOTE tabs structure is defined in the related view.
+  // TODO use variable in preferences last login admin/node
+  $scope.changelog = [];
+  StaticFileResource.get({name: 'changelog.json'}, function(resp) {
+    for (var i = 0; i < 20; i++) {
+      $scope.changelog.push(resp.v[i]);
+    }
+  });
+  $scope.showNewAlerts = true;
+  $scope.searchFun = function(value, index, array) {
+    if ($scope.showNewAlerts) {
+      console.log(value);
+      if (value.alert) {
+        return true;
+      } else {
+        return false;
+      }
+    } else {
+      return true;
+    }
+  }
+}]).
 controller('AdminAdvancedCtrl', ['$scope', '$uibModal',
   function($scope, $uibModal){
   $scope.tabs = [

--- a/client/app/js/controllers/admin/main.js
+++ b/client/app/js/controllers/admin/main.js
@@ -213,28 +213,21 @@ controller('AdminGeneralSettingsCtrl', ['$scope', '$filter', '$http', 'StaticFil
 
   $scope.update_static_files();
 }]).
+service('ChangeLogRes', ['$resource', function($resource) {
+  var res = $resource('data/changelog.json').get();
+  return res.$promise.then(function(r) {
+    return r.v;
+  });
+}]).
 controller('AdminAboutCtrl', ['$scope', 'StaticFileResource', function($scope, StaticFileResource) {
   // NOTE tabs structure is defined in the related view.
   // TODO use variable in preferences last login admin/node
-  $scope.changelog = [];
-  StaticFileResource.get({name: 'changelog.json'}, function(resp) {
-    for (var i = 0; i < 20; i++) {
-      $scope.changelog.push(resp.v[i]);
-    }
-  });
-  $scope.showNewAlerts = true;
-  $scope.searchFun = function(value, index, array) {
-    if ($scope.showNewAlerts) {
-      console.log(value);
-      if (value.alert) {
-        return true;
-      } else {
-        return false;
-      }
-    } else {
-      return true;
-    }
-  }
+  $scope.changelog = $scope.$resolve.changelog;
+  $scope.displayNum = 30;
+  $scope.displayAll = function() { $scope.displayNum = $scope.changelog.length };
+
+  $scope.onlyShowMajor = false;
+  $scope.setMajor = function(b) { $scope.onlyShowMajor = b; };
 }]).
 controller('AdminAdvancedCtrl', ['$scope', '$uibModal',
   function($scope, $uibModal){

--- a/client/app/js/controllers/admin/main.js
+++ b/client/app/js/controllers/admin/main.js
@@ -213,21 +213,20 @@ controller('AdminGeneralSettingsCtrl', ['$scope', '$filter', '$http', 'StaticFil
 
   $scope.update_static_files();
 }]).
-service('ChangeLogRes', ['$resource', function($resource) {
-  var res = $resource('data/changelog.json').get();
-  return res.$promise.then(function(r) {
-    return r.v;
-  });
-}]).
-controller('AdminAboutCtrl', ['$scope', 'StaticFileResource', function($scope, StaticFileResource) {
+controller('AdminAboutCtrl', ['$scope', function($scope) {
   // NOTE tabs structure is defined in the related view.
-  // TODO use variable in preferences last login admin/node
   $scope.changelog = $scope.$resolve.changelog;
-  $scope.displayNum = 30;
-  $scope.displayAll = function() { $scope.displayNum = $scope.changelog.length };
+  $scope.displayNum = 10;
 
   $scope.onlyShowMajor = false;
   $scope.setMajor = function(b) { $scope.onlyShowMajor = b; };
+  $scope.searchFun = function(value, index, array) {
+    if ($scope.onlyShowMajor) {
+      return angular.isDefined(value.alert) && value.alert;
+    } else {
+      return true;
+    }
+  };
 }]).
 controller('AdminAdvancedCtrl', ['$scope', '$uibModal',
   function($scope, $uibModal){

--- a/client/app/js/directives.js
+++ b/client/app/js/directives.js
@@ -355,4 +355,13 @@ directive('requiredAsterisk', function() {
     // TODO Lacks a binding for field.required
     templateUrl: 'views/partials/required_aster.html',
   }
+}).
+directive('releaseMsg', function() {
+  return {
+    restrict: 'A',
+    scope: {
+      change: '=',
+    },
+    templateUrl: 'views/admin/about/releasemsg.html',
+  };
 });

--- a/client/app/js/directives.js
+++ b/client/app/js/directives.js
@@ -359,9 +359,6 @@ directive('requiredAsterisk', function() {
 directive('releaseMsg', function() {
   return {
     restrict: 'A',
-    scope: {
-      change: '=',
-    },
     templateUrl: 'views/admin/about/releasemsg.html',
   };
 });

--- a/client/app/js/services.js
+++ b/client/app/js/services.js
@@ -531,6 +531,9 @@ factory("Access", ["$q", "Authentication", function ($q, Authentication) {
   factory('IdentityAccessRequests', ['GLResource', function(GLResource) {
     return new GLResource('custodian/identityaccessrequests');
 }]).
+  factory('StaticFileResource', ['GLResource', function(GLResource) {
+    return new GLResource('data/:name', {name: '@name'});
+}]).
   factory('AdminContextResource', ['GLResource', function(GLResource) {
     return new GLResource('admin/contexts/:id', {id: '@id'});
 }]).

--- a/client/app/js/services.js
+++ b/client/app/js/services.js
@@ -531,8 +531,11 @@ factory("Access", ["$q", "Authentication", function ($q, Authentication) {
   factory('IdentityAccessRequests', ['GLResource', function(GLResource) {
     return new GLResource('custodian/identityaccessrequests');
 }]).
-  factory('StaticFileResource', ['GLResource', function(GLResource) {
-    return new GLResource('data/:name', {name: '@name'});
+service('ChangeLogRes', ['$resource', function($resource) {
+  var res = $resource('data/changelog.json').get();
+  return res.$promise.then(function(r) {
+    return r.v;
+  });
 }]).
   factory('AdminContextResource', ['GLResource', function(GLResource) {
     return new GLResource('admin/contexts/:id', {id: '@id'});

--- a/client/app/translations.html
+++ b/client/app/translations.html
@@ -35,7 +35,7 @@ removed from context since fields refactor:
 <span data-translate>File overview</span>
 
 /views/admin/landing.html:
-<span data-translate>Landing page</span>
+<span data-translate>Home page</span>
 
 /views/admin/mail.html:
 <span data-translate>Main configuration</span>

--- a/client/app/views/admin/about/changelog.html
+++ b/client/app/views/admin/about/changelog.html
@@ -1,0 +1,8 @@
+<h3>System updates</h3>
+
+<div class="row">
+  <div class="col-md-12" data-ng-repeat="change in changelog track by change.version">
+    <span data-release-msg change=change></span>
+    <hr/>
+  </div>
+</div>

--- a/client/app/views/admin/about/contact.html
+++ b/client/app/views/admin/about/contact.html
@@ -1,0 +1,46 @@
+<div class="title1" data-translate>Welcome to the administration interface!</div>
+<br />
+<div data-translate>This interface may help you understand how the server can be configured and provides some info on how to connect to other GlobaLeaks users and experts.</div>
+  <ul>
+    <li>
+      <span data-translate>You can reach GlobaLeaks's support chat via IRC on OFTC server on channel #globaleaks:</span> 
+      <a href="https://webchat.oftc.net/?channels=globaleaks" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Support Chat</a>
+    </li>
+    <li>
+      <span data-translate>To properly organize your project, please read the following guidelines:</span>
+      <a href="https://docs.google.com/document/d/1Y5h_lSZq-MsefH1LkEjHN5uOfEccyyI4oJgd7tm2Iho/pub" target="_blank" rel="noreferrer noopener"  data-translate>Guidelines on how to start up Whistleblowing Projects</a>
+    </li>
+    <li>
+      <span data-translate>To report a bug or request a feature in GlobaLeaks software, please open a ticket describing the issue you're encountering or the new feature request:</span>
+      <a href="https://github.com/globaleaks/GlobaLeaks/issues" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Ticketing System</a>
+    </li>
+    <li>
+      <span data-translate>Remember to provide proper security advice to Whistleblowers:</span>
+      <a href="https://docs.google.com/document/d/1ZrndvBj9eTg-ooIRfKbXxX18Ie-ODlcjnHjKXSY78Ew/edit?usp=sharing" target="_blank" rel="noreferrer noopener" data-translate>Security advice for whistleblowers</a>
+    </li>
+    <li>
+      <span data-translate>To learn more about GlobaLeaks Security you can read the following document:</span>
+      <a href="https://github.com/globaleaks/globaleaks/wiki#software-security" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Security</a>
+    </li>
+    <li>
+      <span data-translate>To find answers to commonly asked questions use the</span>
+      <a href="https://forum.globaleaks.org" target="_blank" rel="noreferrer noopener"  data-translate>community support forum</a>
+    </li>
+
+  </ul>
+  <div class="title3" data-translate>Contacts</div>
+  <ul>
+    <li>
+      <span data-translate>If you want to tell us more about your project, or you need some help, write us at:</span>
+      <a href="mailto:projects@hermescenter.org">projects@hermescenter.org</a>
+    </li>
+    <li>
+      <span data-translate>For technical support inquiries you can write us at:</span>
+      <a href="mailto:support@hermescenter.org">support@hermescenter.org</a>
+    </li>
+    <li>
+      <span data-translate>Follow us on twitter if you'd like to be profiled by the NSA:</span>
+      <a target="_blank" rel="noreferrer noopener"  href="https://twitter.com/globaleaks">https://twitter.com/globaleaks</a>
+    </li>
+  </ul>
+</div>

--- a/client/app/views/admin/about/contact.html
+++ b/client/app/views/admin/about/contact.html
@@ -1,18 +1,11 @@
 <div class="title1" data-translate>Welcome to the administration interface!</div>
 <br />
 <div data-translate>This interface may help you understand how the server can be configured and provides some info on how to connect to other GlobaLeaks users and experts.</div>
+  <div class="title3" data-translate>Documentation</div>
   <ul>
-    <li>
-      <span data-translate>You can reach GlobaLeaks's support chat via IRC on OFTC server on channel #globaleaks:</span> 
-      <a href="https://webchat.oftc.net/?channels=globaleaks" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Support Chat</a>
-    </li>
     <li>
       <span data-translate>To properly organize your project, please read the following guidelines:</span>
       <a href="https://docs.google.com/document/d/1Y5h_lSZq-MsefH1LkEjHN5uOfEccyyI4oJgd7tm2Iho/pub" target="_blank" rel="noreferrer noopener"  data-translate>Guidelines on how to start up Whistleblowing Projects</a>
-    </li>
-    <li>
-      <span data-translate>To report a bug or request a feature in GlobaLeaks software, please open a ticket describing the issue you're encountering or the new feature request:</span>
-      <a href="https://github.com/globaleaks/GlobaLeaks/issues" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Ticketing System</a>
     </li>
     <li>
       <span data-translate>Remember to provide proper security advice to Whistleblowers:</span>
@@ -20,27 +13,36 @@
     </li>
     <li>
       <span data-translate>To learn more about GlobaLeaks Security you can read the following document:</span>
-      <a href="https://github.com/globaleaks/globaleaks/wiki#software-security" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Security</a>
+      <a href="https://github.com/globaleaks/globaleaks/wiki#software-security" target="_blank" rel="noreferrer noopener" data-translate>GlobaLeaks Security</a>
     </li>
-    <li>
-      <span data-translate>To find answers to commonly asked questions use the</span>
-      <a href="https://forum.globaleaks.org" target="_blank" rel="noreferrer noopener"  data-translate>community support forum</a>
-    </li>
-
   </ul>
-  <div class="title3" data-translate>Contacts</div>
+  <div class="title3" data-translate>Contact</div>
   <ul>
     <li>
-      <span data-translate>If you want to tell us more about your project, or you need some help, write us at:</span>
-      <a href="mailto:projects@hermescenter.org">projects@hermescenter.org</a>
+      <span data-translate>If you need technical support, have general questions, or have new ideas for GlobaLeaks, please post your message on the</span>
+      <a href="https://forum.globaleaks.org" target="_blank" rel="noreferrer noopener" data-translate>community support forum</a>
     </li>
     <li>
-      <span data-translate>For technical support inquiries you can write us at:</span>
-      <a href="mailto:support@hermescenter.org">support@hermescenter.org</a>
+      <span data-translate>If your non-profit needs support for investigative journalism, activism or a human rights defense project, contact the </span>
+      <a href="mailto:projects@hermescenter.org" target="_blank" rel="noreferrer noopener" data-translate>Hermes Center</a>
     </li>
     <li>
-      <span data-translate>Follow us on twitter if you'd like to be profiled by the NSA:</span>
-      <a target="_blank" rel="noreferrer noopener"  href="https://twitter.com/globaleaks">https://twitter.com/globaleaks</a>
+      <span data-translate>If you want to contribute to software development or report a bug, please open an issue in our ticketing system on </span>
+      <a href="https://github.com/globaleaks/GlobaLeaks/issues/" target="_blank" rel="noreferrer noopener" data-translate>Github</a>
+    </li>
+    <li>
+      <span data-translate>For professional support and development of anti corruption and compliance projects contact the social enterprise maintaining GlobaLeaks</span>
+      <a href="https://whistleblowingsolutions.it" target="_blank" rel="noreferrer noopener">Whistleblowing Solutions Srl</a>
+    </li>
+    <li>
+      <span data-translate>Join our IRC chat channel on the irc.oftc.net network</span>
+      <a target="_blank" rel="noreferrer noopener" href="https://webchat.oftc.net/?nick=gl-guest.&channels=globaleaks">#globaleaks</a>
+    </li>
+    <li>
+      <span data-translate>Follow the project on</span>
+      <a target="_blank" rel="noreferrer noopener" href="https://twitter.com/globaleaks">Twitter</a>
+      <span data-translate>or</span>
+      <a target="_blank" rel="noreferrer noopener" href="https://www.facebook.com/globaleaks">Facebook</a>
     </li>
   </ul>
 </div>

--- a/client/app/views/admin/about/license.html
+++ b/client/app/views/admin/about/license.html
@@ -1,0 +1,681 @@
+<pre style="width: 85ch;">
+-------------------------------------------------------------------------------
+GlobaLeaks
+Copyright (c) 2011-2017 - Hermes Center for Transparency and Digital Human Rights
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see (http://www.gnu.org/licenses/).
+-------------------------------------------------------------------------------
+                               AGPLv3 LICENSE
+-------------------------------------------------------------------------------
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. (http://fsf.org/)
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+-------------------------------------------------------------------------------
+           ADDITIONAL TERMS AS PERMITTED BY SECTION 7b OF AGPLv3
+-------------------------------------------------------------------------------
+This program was created by Hermes Center for Transparency and Digital
+Human Rights (https://www.hermescenter.org) and by Whistleblowing
+Solutions I.S. SRL (https://whistleblowingsolutions.it) under the
+name "GlobaLeaks" (https://www.globaleaks.org).
+
+As permitted by section 7b of the AGPLv3, we require the preservation of the
+legal notices, copyrights notices and author attributions in the program and
+in its documentation or in the Appropriate Legal Notices displayed by works
+containing it.
+
+This program displays such notices in each user interface screen with an
+author attribution that includes "Powered by GlobaLeaks".
+The author attribution must be clearly visible with size of the fonts
+and icons proportionate to the user interface being used.
+
+For works containing this program or any covered work, each interactive
+user interface must include a prominent and conveniently accessible
+feature for the display of Appropriate Legal Notices. This display
+must include author attributions and copyright notices as found in this
+program. This display of these author attributions must be convenient
+for a user wishing to browse credits, shown in a manner separate and
+distinct from license texts, and commensurately prominent with respect
+to other author attributions. To the extent that it is technically
+feasible and not obtrusive, the graphical form of these author
+attributions, such as a "Powered by GlobaLeaks" logo, must be preserved;
+otherwise, a textual equivalent is permitted. When users click on the
+"Powered by GlobaLeaks" logo it must direct them back to the
+https://www.globaleaks.org website.
+
+Any party that wishes to remove the author attribution from the user
+interfaces is required to obtain written consent from
+Whistleblowing Solutions I.S. SRL.
+
+The purpose of this non-profit social enterprise is to support the
+development of the GlobaLeaks software while maintaining it entirely
+as free software available for public interests purposes pursuing the
+social goal of protecting whistleblowers and increasing transparency.
+-------------------------------------------------------------------------------
+</pre>

--- a/client/app/views/admin/about/releasemsg.html
+++ b/client/app/views/admin/about/releasemsg.html
@@ -1,0 +1,11 @@
+<div>
+  <div class="info small">
+    <span data-ng-show="::change.alert"><span class="glyphicon glyphicon-exclamation-sign text-danger"></span>
+      <span data-translate>Major changes</span>
+    </span>
+    <span data-ng-hide="::change.alert"><span class="glyphicon glyphicon-plus-sign text-muted"></span>
+      <span data-translate>Minor changes</span>
+    </span>
+  </div>
+  <pre style="width: 85ch; white-space: pre-line;">{{::change.txt }}</pre>
+</div>

--- a/client/app/views/admin/landing.html
+++ b/client/app/views/admin/landing.html
@@ -2,40 +2,111 @@
   <div id="ConfigSidebarBox" class="col-md-3" data-ng-include="'views/admin/sidebar.html'"></div>
   <div class="col-md-9">
     <div class="row">
-      <div>
-        <div class="title1" data-translate>Welcome to the administration interface!</div>
-        <br />
-        <div data-translate>This interface may help you understand how the server can be configured and provides some info on how to connect to other GlobaLeaks users and experts.</div>
-        <ul>
-          <li>
-            <span data-translate>You can reach GlobaLeaks's support chat via IRC on OFTC server on channel #globaleaks:</span> <a href="https://webchat.oftc.net/?channels=globaleaks" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Support Chat</a>
-          </li>
-          <li>
-            <span data-translate>To properly organize your project, please read the following guidelines:</span> <a href="https://docs.google.com/document/d/1Y5h_lSZq-MsefH1LkEjHN5uOfEccyyI4oJgd7tm2Iho/pub" target="_blank" rel="noreferrer noopener"  data-translate>Guidelines on how to start up Whistleblowing Projects</a>
-          </li>
-          <li>
-            <span data-translate>To report a bug or request a feature in GlobaLeaks software, please open a ticket describing the issue you're encountering or the new feature request:</span> <a href="https://github.com/globaleaks/GlobaLeaks/issues" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Ticketing System</a>
-          </li>
-          <li>
-            <span data-translate>Remember to provide proper security advice to Whistleblowers:</span> <a href="https://docs.google.com/document/d/1ZrndvBj9eTg-ooIRfKbXxX18Ie-ODlcjnHjKXSY78Ew/edit?usp=sharing" target="_blank" rel="noreferrer noopener" data-translate>Security advice for whistleblowers</a>
-          </li>
-          <li>
-            <span data-translate>To know more about GlobaLeaks Security you can read the following document:</span> <a href="https://github.com/globaleaks/globaleaks/wiki#software-security" target="_blank" rel="noreferrer noopener"  data-translate>GlobaLeaks Security</a>
-          </li>
-        </ul>
-        <div class="title3" data-translate>Contacts</div>
-        <ul>
-          <li>
-            <span data-translate>If you want to tell us more about your project, or you need some help, write us at:</span> <a href="mailto:projects@hermescenter.org">projects@hermescenter.org</a>
-          </li>
-          <li>
-            <span data-translate>For technical support inquiries you can write us at:</span> <a href="mailto:support@hermescenter.org">support@hermescenter.org</a>
-          </li>
-          <li>
-            <span data-translate>Follow us on Twitter if you like to be profiled by NSA:</span> <a target="_blank" rel="noreferrer noopener"  href="https://twitter.com/globaleaks">https://twitter.com/globaleaks</a>
-          </li>
-        </ul>
+      <div data-ng-controller="AdminAboutCtrl">
+        <uib-tabset>
+          <uib-tab data-index="0" heading="{{'Contact' | translate}}">
+            <div class="tab-content" data-ng-include="'views/admin/about/contact.html'"></div>
+          </uib-tab>
+
+          <uib-tab data-index="1">
+            <uib-tab-heading>
+              <span data-translate>Change log</span> <i data-ng-hide="tabset.active == 1" class="glyphicon glyphicon-exclamation-sign text-danger"></i>
+            </uib-tab-heading>
+            <div class="tab-content">
+              <div class="btn-group" role="group" aria-label="...">
+                <button type="button" class="btn btn-default"
+                        data-ng-disabled="showNewAlerts"
+                        data-ng-class="{'active': showNewAlerts}"
+                        data-ng-click="showNewAlerts = true">
+                   <span data-translate>Major changes</span> <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
+                </button>
+                <button type="button" class="btn btn-default"
+                        data-ng-disabled="!showNewAlerts"
+                        data-ng-class="{'active': !showNewAlerts}"
+                        data-ng-click="showNewAlerts = false">
+                  <span data-translate>All</span>
+                </button>
+                <span class="btn btn-default" style=""><span data-translate>Displaying from</span> 2017-03-03</span>
+              </div>
+              <br/>
+              <div class="row">
+                <div class="col-md-12" data-ng-repeat="change in changelog | filter:searchFun track by change.version">
+                  <hr/>
+                  <span data-release-msg change=change></span>
+                </div>
+              </div>
+            </div>
+          </uib-tab>
+
+          <uib-tab data-index="2" heading="{{ 'License' | translate}}">
+            <div class="tab-content">
+<pre style="width: 85ch;">
+-------------------------------------------------------------------------------
+GlobaLeaks
+Copyright (c) 2011-2017 - Hermes Center for Transparency and Digital Human Rights
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+
+The full text of the license is available at <a href="/data/license.txt" target="_blank" rel="noreferrer noopener">Full text</a> of the GNU Affero
+General Public License is available. If not, see <http://www.gnu.org/licenses/>.
+-------------------------------------------------------------------------------
+</pre>
+<pre style="width: 85ch;">
+-------------------------------------------------------------------------------
+           ADDITIONAL TERMS AS PERMITTED BY SECTION 7b OF AGPLv3
+-------------------------------------------------------------------------------
+This program was created by Hermes Center for Transparency and Digital
+Human Rights (https://www.hermescenter.org) and by Whistleblowing
+Solutions I.S. SRL (https://whistleblowingsolutions.it) under the
+name "GlobaLeaks" (https://www.globaleaks.org).
+
+As permitted by section 7b of the AGPLv3, we require the preservation of the
+legal notices, copyrights notices and author attributions in the program and
+in its documentation or in the Appropriate Legal Notices displayed by works
+containing it.
+
+This program displays such notices in each user interface screen with an
+author attribution that includes "Powered by GlobaLeaks".
+The author attribution must be clearly visible with size of the fonts
+and icons proportionate to the user interface being used.
+
+For works containing this program or any covered work, each interactive
+user interface must include a prominent and conveniently accessible
+feature for the display of Appropriate Legal Notices. This display
+must include author attributions and copyright notices as found in this
+program. This display of these author attributions must be convenient
+for a user wishing to browse credits, shown in a manner separate and
+distinct from license texts, and commensurately prominent with respect
+to other author attributions. To the extent that it is technically
+feasible and not obtrusive, the graphical form of these author
+attributions, such as a "Powered by GlobaLeaks" logo, must be preserved;
+otherwise, a textual equivalent is permitted. When users click on the
+"Powered by GlobaLeaks" logo it must direct them back to the
+https://www.globaleaks.org website.
+
+Any party that wishes to remove the author attribution from the user
+interfaces is required to obtain written consent from
+Whistleblowing Solutions I.S. SRL.
+
+The purpose of this non-profit social enterprise is to support the
+development of the GlobaLeaks software while maintaining it entirely
+as free software available for public interests purposes pursuing the
+social goal of protecting whistleblowers and increasing transparency.
+-------------------------------------------------------------------------------
+</pre>
+              <!--<pre style="width: 85ch;" ng-include="'data/license.txt'"></pre>-->
+            </div>
+          </uib-tab>
+        </uib-tabset>
       </div>
-    </div>
   </div>
 </div>

--- a/client/app/views/admin/landing.html
+++ b/client/app/views/admin/landing.html
@@ -46,70 +46,7 @@
 
           <uib-tab data-index="2" heading="{{ 'License' | translate}}">
             <div class="tab-content">
-<pre style="width: 85ch;">
--------------------------------------------------------------------------------
-GlobaLeaks
-Copyright (c) 2011-2017 - Hermes Center for Transparency and Digital Human Rights
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-
-The full text of the license is available at <a href="/data/license.txt" target="_blank" rel="noreferrer noopener">Full text</a> of the GNU Affero
-General Public License is available. If not, see <http://www.gnu.org/licenses/>.
--------------------------------------------------------------------------------
-</pre>
-<pre style="width: 85ch;">
--------------------------------------------------------------------------------
-           ADDITIONAL TERMS AS PERMITTED BY SECTION 7b OF AGPLv3
--------------------------------------------------------------------------------
-This program was created by Hermes Center for Transparency and Digital
-Human Rights (https://www.hermescenter.org) and by Whistleblowing
-Solutions I.S. SRL (https://whistleblowingsolutions.it) under the
-name "GlobaLeaks" (https://www.globaleaks.org).
-
-As permitted by section 7b of the AGPLv3, we require the preservation of the
-legal notices, copyrights notices and author attributions in the program and
-in its documentation or in the Appropriate Legal Notices displayed by works
-containing it.
-
-This program displays such notices in each user interface screen with an
-author attribution that includes "Powered by GlobaLeaks".
-The author attribution must be clearly visible with size of the fonts
-and icons proportionate to the user interface being used.
-
-For works containing this program or any covered work, each interactive
-user interface must include a prominent and conveniently accessible
-feature for the display of Appropriate Legal Notices. This display
-must include author attributions and copyright notices as found in this
-program. This display of these author attributions must be convenient
-for a user wishing to browse credits, shown in a manner separate and
-distinct from license texts, and commensurately prominent with respect
-to other author attributions. To the extent that it is technically
-feasible and not obtrusive, the graphical form of these author
-attributions, such as a "Powered by GlobaLeaks" logo, must be preserved;
-otherwise, a textual equivalent is permitted. When users click on the
-"Powered by GlobaLeaks" logo it must direct them back to the
-https://www.globaleaks.org website.
-
-Any party that wishes to remove the author attribution from the user
-interfaces is required to obtain written consent from
-Whistleblowing Solutions I.S. SRL.
-
-The purpose of this non-profit social enterprise is to support the
-development of the GlobaLeaks software while maintaining it entirely
-as free software available for public interests purposes pursuing the
-social goal of protecting whistleblowers and increasing transparency.
--------------------------------------------------------------------------------
-</pre>
-              <!--<pre style="width: 85ch;" ng-include="'data/license.txt'"></pre>-->
+              <div data-ng-include="'views/admin/about/license.html'"></div>
             </div>
           </uib-tab>
         </uib-tabset>

--- a/client/app/views/admin/landing.html
+++ b/client/app/views/admin/landing.html
@@ -10,31 +10,36 @@
 
           <uib-tab data-index="1">
             <uib-tab-heading>
-              <span data-translate>Change log</span> <i data-ng-hide="tabset.active == 1" class="glyphicon glyphicon-exclamation-sign text-danger"></i>
+              <span data-translate>Change log</span>
             </uib-tab-heading>
             <div class="tab-content">
-              <div class="btn-group" role="group" aria-label="...">
+              <div class="btn-group" role="group" aria-label="Release notes toggle.">
                 <button type="button" class="btn btn-default"
-                        data-ng-disabled="showNewAlerts"
-                        data-ng-class="{'active': showNewAlerts}"
-                        data-ng-click="showNewAlerts = true">
-                   <span data-translate>Major changes</span> <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
-                </button>
-                <button type="button" class="btn btn-default"
-                        data-ng-disabled="!showNewAlerts"
-                        data-ng-class="{'active': !showNewAlerts}"
-                        data-ng-click="showNewAlerts = false">
+                        data-ng-disabled="!onlyShowMajor"
+                        data-ng-click="setMajor(false)"
+                        data-ng-class="{'active': !onlyShowMajor}"
+                        >
                   <span data-translate>All</span>
                 </button>
-                <span class="btn btn-default" style=""><span data-translate>Displaying from</span> 2017-03-03</span>
+                <button type="button" class="btn btn-default"
+                        data-ng-disabled="onlyShowMajor"
+                        data-ng-click="setMajor(true)"
+                        data-ng-class="{'active': onlyShowMajor}">
+                   <span data-translate>Major changes</span> <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
+                </button>
               </div>
               <br/>
               <div class="row">
-                <div class="col-md-12" data-ng-repeat="change in changelog | filter:searchFun track by change.version">
+                <div class="col-md-12" data-ng-repeat="change in $resolve.changelog | filter:searchFun | limitTo:displayNum">
                   <hr/>
-                  <span data-release-msg change=change></span>
+                  <span data-release-msg></span>
                 </div>
               </div>
+              <a type="button" class="btn btn-default"
+                href="https://raw.githubusercontent.com/globaleaks/GlobaLeaks/master/CHANGELOG">
+                <span data-translate>More</span>
+                <i class="glyphicon glyphicon glyphicon-link"></i>
+              </a>
             </div>
           </uib-tab>
 

--- a/client/app/views/admin/landing.html
+++ b/client/app/views/admin/landing.html
@@ -4,7 +4,7 @@
     <div class="row">
       <div data-ng-controller="AdminAboutCtrl">
         <uib-tabset>
-          <uib-tab data-index="0" heading="{{'Contact' | translate}}">
+          <uib-tab data-index="0" heading="{{'Home' | translate}}">
             <div class="tab-content" data-ng-include="'views/admin/about/contact.html'"></div>
           </uib-tab>
 
@@ -25,18 +25,19 @@
                         data-ng-disabled="onlyShowMajor"
                         data-ng-click="setMajor(true)"
                         data-ng-class="{'active': onlyShowMajor}">
-                   <span data-translate>Major changes</span> <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
+                  <span data-translate>Major changes</span> <i class="glyphicon glyphicon-exclamation-sign text-danger"></i>
                 </button>
               </div>
-              <br/>
               <div class="row">
                 <div class="col-md-12" data-ng-repeat="change in $resolve.changelog | filter:searchFun | limitTo:displayNum">
                   <hr/>
                   <span data-release-msg></span>
                 </div>
               </div>
+              <hr/>
               <a type="button" class="btn btn-default"
-                href="https://raw.githubusercontent.com/globaleaks/GlobaLeaks/master/CHANGELOG">
+                 href="https://raw.githubusercontent.com/globaleaks/GlobaLeaks/master/CHANGELOG"
+                 target="_blank" rel="noreferrer noopener">
                 <span data-translate>More</span>
                 <i class="glyphicon glyphicon glyphicon-link"></i>
               </a>

--- a/client/app/views/admin/sidebar.html
+++ b/client/app/views/admin/sidebar.html
@@ -1,4 +1,11 @@
 <ul class="nav nav-pills nav-stacked">
+  <li data-ng-class="active.landing">
+    <a href="#/admin/landing">
+      <i class="glyphicon glyphicon-chevron-right"></i>
+      <span data-translate>About</span>
+    </a>
+  </li>
+
   <li data-ng-class="active.content">
     <a href="#/admin/content">
       <i class="glyphicon glyphicon-chevron-right"></i>

--- a/client/tests/end2end/test-admin-navigate-sections.js
+++ b/client/tests/end2end/test-admin-navigate-sections.js
@@ -3,6 +3,7 @@ describe('verify navigation of admin sections', function() {
   // navigation of the admin section without triggering any exception
 
   it('should should navigate through admin sections', function() {
+    element(by.cssContainingText("a", "About")).click();
     element(by.cssContainingText("a", "General settings")).click();
     element(by.cssContainingText("a", "Main configuration")).click();
     element(by.cssContainingText("a", "Theme customization")).click();


### PR DESCRIPTION
This PR closes #1949 without requiring backend changes or the usage of local storage to display the change set the user has already seen. We generally want the ability to notify the user of a set of events that have occurred since the last time they logged in. These change log entries are now one of those events.

Notably here the backend now exports `changelog.json` in `./data/`. This may be caught by future pen testers eager to point out that it is not a best practice, but after some disucssion with @evilaliv3 we are not convinced it is good practice to withhold the system version.

Finally please note the `resolve` usage in `app.js`. This form of promise injection is idiomatic and will be required in the move to angular v2. Note that the changelog list is injected into the scope as `$scope.$resolve.changelog`