### PR TITLE
WIP: Add docker support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ client/dest
 client/coverage
 client/node_modules/
 client/pot/
+
+docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM node:latest
+
+
+# install build dependencies (and vim ;-) )
+RUN apt update
+# todo: we probably don't need all of this.  vim is just for debugging
+RUN apt install -y wget curl tzdata vim net-tools software-properties-common python-pip python-dev
+RUN npm install -g grunt-cli
+
+# add tor repo and key (we can't do this until after we installed software-properties-common above)
+RUN gpg --keyserver keys.gnupg.net --recv A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89
+RUN gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
+RUN add-apt-repository 'deb http://deb.torproject.org/torproject.org jessie main'
+
+RUN apt update
+RUN apt install -y tor deb.torproject.org-keyring
+
+# install nodejs deps
+COPY ./client/package.json /usr/src/globaleaks/client/package.json
+COPY ./client/npm-shrinkwrap.json /usr/src/globaleaks/client/npm-shrinkwrap.json
+WORKDIR /usr/src/globaleaks/client
+RUN npm install
+COPY ./client /usr/src/globaleaks/client
+RUN grunt copy:sources
+
+# install python deps
+COPY ./backend /usr/src/globaleaks/backend
+WORKDIR /usr/src/globaleaks/backend
+# update pip to fix urllib3 issue, ref: https://stackoverflow.com/a/29081240/5750032
+RUN pip install -U pip
+RUN pip install -r ./requirements/requirements-jessie.txt
+# update python-requests to fix urllib3 issue, ref: https://stackoverflow.com/a/29081240/5750032
+RUN pip install requests==2.6.0
+
+# globaleaks won't start unless this dir exists so it can write a pid file.
+RUN mkdir /var/run/globaleaks
+
+COPY ./debian/default /etc/default/globaleaks
+COPY . /usr/src/globaleaks
+
+
+# Disable AppArmor and Network Sandboxing.
+RUN sed -i -n -e '/^APPARMOR_SANDBOXING=/!p' -e '$aAPPARMOR_SANDBOXING=0' /etc/default/globaleaks
+RUN sed -i -n -e '/^NETWORK_SANDBOXING=/!p' -e '$aNETWORK_SANDBOXING=0' /etc/default/globaleaks
+
+# ports exposed by GlobaLeaks
+EXPOSE 80
+EXPOSE 443
+
+# ports for tor (but maybe we shouldn't expose these... this tor instance is ONLY for GlobaLeaks)
+EXPOSE 8082
+EXPOSE 8083
+
+# todo: a better docker entrypoint.  Tor needs to run alongside globaleaks.  We could move tor into it's own container, but that makes this image harder to use.
+COPY ./docker-entrypoint.sh /opt/docker-entrypoint.sh
+RUN chmod +x /opt/docker-entrypoint.sh
+ENTRYPOINT /opt/docker-entrypoint.sh
+VOLUME /var/globaleaks/
+VOLUME /etc/default/
+# todo: this image doesn't shut down gracefully, probably because of the docker-entrypoint above.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:8
 
 
 # install build dependencies (and vim ;-) )
@@ -54,7 +54,6 @@ EXPOSE 8083
 # todo: a better docker entrypoint.  Tor needs to run alongside globaleaks.  We could move tor into it's own container, but that makes this image harder to use.
 COPY ./docker-entrypoint.sh /opt/docker-entrypoint.sh
 RUN chmod +x /opt/docker-entrypoint.sh
-ENTRYPOINT /opt/docker-entrypoint.sh
+ENTRYPOINT ["/opt/docker-entrypoint.sh"]
 VOLUME /var/globaleaks/
 VOLUME /etc/default/
-# todo: this image doesn't shut down gracefully, probably because of the docker-entrypoint above.

--- a/backend/bin/globaleaks
+++ b/backend/bin/globaleaks
@@ -119,6 +119,9 @@ Settings.parser.add_option("-o", "--orm-debug", action='store_true',
 Settings.parser.add_option("-v", "--version", action='store_true',
     help="show the version of the software")
 
+Settings.parser.add_option("--allow-run-as-root", action='store_true',
+    help="Allow GlobaLeaks to be run as root, useful for running GlobaLeaks inside of a Docker container.",
+    dest="allow_run_as_root", default=False)
 
 # here the options are parsed, because sys.argv array is whack below
 (Settings.cmdline_options, args) = Settings.parser.parse_args()

--- a/backend/globaleaks/settings.py
+++ b/backend/globaleaks/settings.py
@@ -65,6 +65,7 @@ class SettingsClass(object):
         # daemonize the process
         self.nodaemon = False
 
+        self.allow_run_as_root = False
         self.bind_address = '0.0.0.0'
         self.bind_remote_ports = [80, 443]
         self.bind_local_ports = [8082, 8083]
@@ -246,6 +247,7 @@ class SettingsClass(object):
 
     def load_cmdline_options(self):
         self.nodaemon = self.cmdline_options.nodaemon
+        self.allow_run_as_root = self.cmdline_options.allow_run_as_root
 
         if self.cmdline_options.disable_swap:
             self.disable_swap = True
@@ -282,7 +284,7 @@ class SettingsClass(object):
             self.gid = grp.getgrnam(self.cmdline_options.group).gr_gid
             self.uid = os.getuid()
 
-        if self.uid == 0 or self.gid == 0:
+        if (self.uid == 0 or self.gid == 0) and not self.allow_run_as_root:
             self.print_msg("Invalid user: cannot run as root")
             sys.exit(1)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3"
+services:
+  globaleaks:
+    image: globaleaks
+    build: .
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - ./data/var/:/var/globaleaks
+    entrypoint: bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - 443:443
     volumes:
       - ./data/var/:/var/globaleaks
-    entrypoint: bash
+    entrypoint: bash # uncomment this line and run docker-compose run globaleaks to get inside the docker container easily.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
       - 443:443
     volumes:
       - ./data/var/:/var/globaleaks
-    entrypoint: bash # uncomment this line and run docker-compose run globaleaks to get inside the docker container easily.
+#    entrypoint: bash # uncomment this line and run docker-compose run globaleaks to get inside the docker container easily.

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+echo "**** Starting GlobaLeaks ..."
+service tor start
+/usr/src/globaleaks/backend/bin/globaleaks --allow-run-as-root -n

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 echo "**** Starting GlobaLeaks ..."
 service tor start
-/usr/src/globaleaks/backend/bin/globaleaks --allow-run-as-root -n
+exec /usr/src/globaleaks/backend/bin/globaleaks --allow-run-as-root -n


### PR DESCRIPTION
This pull request has 2 primary changes:

1. It adds the option `--allow-run-as-root` to simplify execution of GlobaLeaks in a Docker container.
2. It adds a `Dockerfile` and `docker-entrypoint.sh`.

Additionally, it adds a `docker-compose.yml` and adds an entry to `.gitignore` to avoid committing volumes used by `docker-compose.yml`.  The `docker-compose.yml` is not required for anything, but it makes a nice example for copy and paste, and makes it easier to develop and test the `Dockerfile`.

This PR is incomplete.  I can't connect to the container on port 80 or 443.  However, the Tor hidden service works so this PR is almost there.

Resolves #692 