### PR TITLE
Correctly handle async validation for PGP keys

### DIFF
--- a/backend/requirements/requirements-xenial.txt
+++ b/backend/requirements/requirements-xenial.txt
@@ -11,7 +11,7 @@ pyasn1==0.1.9
 pyasn1_modules==0.0.7
 pycparser==2.14
 python_debian==0.1.28
-python_gnupg==0.3.8
+python_gnupg==0.4.1
 requests==2.9.1
 scrypt==0.6.1
 service_identity==16.0.0

--- a/client/app/js/controllers/preferences.js
+++ b/client/app/js/controllers/preferences.js
@@ -1,5 +1,5 @@
-GLClient.controller('PreferencesCtrl', ['$scope', '$rootScope', 'Utils', 'CONSTANTS',
-  function($scope, $rootScope, Utils, CONSTANTS) {
+GLClient.controller('PreferencesCtrl', ['$scope', '$q', '$rootScope', 'Utils', 'CONSTANTS',
+  function($scope, $q, $rootScope, Utils, CONSTANTS) {
     $scope.tabs = [
       {
         title: "Preferences",

--- a/client/app/js/crypto/main.js
+++ b/client/app/js/crypto/main.js
@@ -108,7 +108,7 @@ angular.module('GLBrowserCrypto', [])
         }
 
         // Verify expiration, revocation, and self sigs.
-        key.verifyPrimaryKey().then(keyStatus => {
+        key.verifyPrimaryKey().then(function(keyStatus) {
           if (keyStatus === pgp.enums.keyStatus.valid) {
             defer.resolve(true);
           } else {

--- a/client/app/js/directives.js
+++ b/client/app/js/directives.js
@@ -259,10 +259,11 @@ directive('pgpPubkeyDisplay', ['pgp', 'glbcKeyLib', function(pgp, glbcKeyLib) {
         if (newVal === "") {
           return;
         }
-        scope.is_valid_key = glbcKeyLib.validPublicKey(newVal);
-        if (scope.is_valid_key) {
-          scope.key_details = pgpKeyDetails(newVal);
-        }
+        glbcKeyLib.validPublicKey(newVal).then(result => {
+          if (result) {
+            scope.key_details = pgpKeyDetails(newVal);
+          }
+        });
       });
     },
   };
@@ -272,7 +273,7 @@ directive('pgpPubkeyDisplay', ['pgp', 'glbcKeyLib', function(pgp, glbcKeyLib) {
 // containing form's ngModelController NOT the ngModel bound to the value of the
 // text-area itself. If the key word 'canBeEmpty' the pgp key validator is disabled
 // when the textarea's input is empty.
-directive('pgpPubkeyValidator', ['glbcKeyLib', function(glbcKeyLib) {
+directive('pgpPubkeyValidator', ['$q', 'glbcKeyLib', function($q, glbcKeyLib) {
   // scope is the directives scope
   // elem is a jqlite reference to the bound element
   // attrs is the list of directives on the element
@@ -282,14 +283,16 @@ directive('pgpPubkeyValidator', ['glbcKeyLib', function(glbcKeyLib) {
     scope.canBeEmpty = scope.pgpPubkeyValidator === 'canBeEmpty';
 
     // modelValue is the models value, viewVal is displayed on the page.
-    ngModel.$validators.pgpPubKeyValidator = function(modelVal) {
+    ngModel.$asyncValidators.pgpPubKeyValidator = function(modelVal) {
       // Check for obvious problems.
+      var defer = $q.defer();
+
       if (typeof modelVal !== 'string') {
         modelVal = '';
       }
 
       if (scope.canBeEmpty && modelVal === '') {
-        return true;
+        return $q.reject();
       }
 
       return glbcKeyLib.validPublicKey(modelVal);

--- a/client/app/js/directives.js
+++ b/client/app/js/directives.js
@@ -259,7 +259,7 @@ directive('pgpPubkeyDisplay', ['pgp', 'glbcKeyLib', function(pgp, glbcKeyLib) {
         if (newVal === "") {
           return;
         }
-        glbcKeyLib.validPublicKey(newVal).then(result => {
+        glbcKeyLib.validPublicKey(newVal).then(function(result) {
           if (result) {
             scope.key_details = pgpKeyDetails(newVal);
           }
@@ -285,8 +285,6 @@ directive('pgpPubkeyValidator', ['$q', 'glbcKeyLib', function($q, glbcKeyLib) {
     // modelValue is the models value, viewVal is displayed on the page.
     ngModel.$asyncValidators.pgpPubKeyValidator = function(modelVal) {
       // Check for obvious problems.
-      var defer = $q.defer();
-
       if (typeof modelVal !== 'string') {
         modelVal = '';
       }

--- a/client/npm-shrinkwrap.json
+++ b/client/npm-shrinkwrap.json
@@ -2049,7 +2049,7 @@
       "dev": true
     },
     "elliptic": {
-      "version": "github:openpgpjs/elliptic#8b8ee8475b86402b125d4ad3a863a4ccd762e48c",
+      "version": "github:openpgpjs/elliptic#e187e706e11fa51bcd20e46e5119054be4e2a4a6",
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
@@ -7666,16 +7666,16 @@
       "dev": true
     },
     "openpgp": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-3.0.0.tgz",
-      "integrity": "sha512-meIqCm8OJVHPfUyZNoXHGNQyaZAhlI3KMn+3eyffbplbEqhS/XMdSHjwVR5TjDsRosML9H/HotfMCVNB8ZqMWw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-3.0.2.tgz",
+      "integrity": "sha512-uRCB74x3dJKhVzFH1yMwGLdpKnfMkxXrK/iW2v2ptx/IluroNWIJwm6n4/K+ZFesaMC1xeFzJeCJKs6mdCeQKQ==",
       "requires": {
         "asmcrypto.js": "0.22.0",
         "asn1.js": "5.0.0",
         "bn.js": "4.11.8",
         "buffer": "5.1.0",
         "compressjs": "github:openpgpjs/compressjs#ce5ccbede61f075926081e29573c8a79ddf10d88",
-        "elliptic": "github:openpgpjs/elliptic#8b8ee8475b86402b125d4ad3a863a4ccd762e48c",
+        "elliptic": "github:openpgpjs/elliptic#e187e706e11fa51bcd20e46e5119054be4e2a4a6",
         "hash.js": "1.1.3",
         "node-fetch": "1.7.3",
         "node-localstorage": "1.3.0",

--- a/client/package.json
+++ b/client/package.json
@@ -27,7 +27,7 @@
     "angular-zxcvbn": "3.2.2",
     "bootstrap-inline-rtl": "3.3.7",
     "d3": "4.13.0",
-    "openpgp": "3.0.0",
+    "openpgp": "3.0.2",
     "scrypt-async": "2.0.0",
     "stacktrace-js": "2.0.0",
     "ui-select": "0.19.8",


### PR DESCRIPTION
Fixes #2218 due to multiple changes.

OpenPGP.js 3.0.2 is required to resolve issues with some PGP keys that have
errorously reported expired.

python-gnupg 0.4.1 allows for newer versions of GnuPG to work successfully.

glbcKeyLib.validPublicKey was modified to properly handle some operations
that are async in openpgpjs; the directive and controllers were modified to
become asyncValidators.

Signed-off-by: Michael Casadevall <michael@casadevall.pro>