### PR TITLE
Fix salt to be consistent on Py2/Py3.

### DIFF
--- a/backend/globaleaks/utils/security.py
+++ b/backend/globaleaks/utils/security.py
@@ -68,7 +68,7 @@ def generateRandomSalt():
     # an exception). As B64 encoded data is always ASCII, this should be
     # able to go safely in and out of the database.
 
-    return str(base64.b64encode(os.urandom(16)))
+    return base64.b64encode(os.urandom(16)).decode()
 
 
 def generate_api_token():


### PR DESCRIPTION
Signed-off-by: Michael Casadevall <michael@casadevall.pro>

This likely needs a migration fix to go with it. As far as I can tell, we don't use salt anywhere ATM, so maybe we can blow it away and just regenerate?