### PR TITLE
Fix #2454 

### DIFF
--- a/client/app/views/partials/user.html
+++ b/client/app/views/partials/user.html
@@ -7,7 +7,7 @@
   <div id="LoginStatusBox" class="row" data-ng-if="Utils.showUserStatusBox()">
     <div class="pull-right">
       <span id="UsernameBox" data-ng-if="session.role !== 'whistleblower'">
-        <label>{{::preferences.name}}</label>
+        <label>{{preferences.name}}</label>
         <span class="text-separator">|</span>
       </span>
       <span id="HomeLinkBox" data-ng-if="session.role !== 'whistleblower'">


### PR DESCRIPTION
#2454 Username are not the one of logged-in user.

Removed one-time binding on the preferences.name variable 