### PR TITLE
After migration 45 fieldattr bool reads always to False

### DIFF
--- a/backend/globaleaks/handlers/public.py
+++ b/backend/globaleaks/handlers/public.py
@@ -242,9 +242,7 @@ def serialize_field_attr(attr, language):
         'value': attr.value
     }
 
-    if attr.type == 'bool':
-        ret_dict['value'] = True if ret_dict['value'] == 'True' else False
-    elif attr.type == u'localized':
+    if attr.type == u'localized':
         get_localized_values(ret_dict, ret_dict, ['value'], language)
 
     return ret_dict


### PR DESCRIPTION
Fix for #2463

backend/globaleaks/db/migrations/update_45/__init__.py
```
def migrate_FieldAttr
[...]
            if new_obj.type == 'bool':
                new_obj.value = new_obj.value == u'True'
[...]
```

With this bool value became really boolean