### PR TITLE
Fix admin table cell widths

### DIFF
--- a/client/app/views/admin/content/tab5.html
+++ b/client/app/views/admin/content/tab5.html
@@ -34,9 +34,9 @@
       <table class="table table-striped">
         <thead>
           <tr>
-            <th class="col-md-3" data-translate>Original text</th>
-            <th class="col-md-3" data-translate>Original translation</th>
-            <th class="col-md-3" data-translate>Custom translation</th>
+            <th data-translate>Original text</th>
+            <th data-translate>Original translation</th>
+            <th data-translate>Custom translation</th>
           </tr>
         </thead>
         <tbody>

--- a/client/app/views/admin/network/url_redirects.html
+++ b/client/app/views/admin/network/url_redirects.html
@@ -29,9 +29,9 @@
     <table class="table">
       <thead>
         <tr>
-          <th class="col-md-3" data-translate>From</th>
-          <th class="col-md-9" data-translate>To</th>
-          <th class="col-md-1"></th>
+          <th data-translate>From</th>
+          <th data-translate>To</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>


### PR DESCRIPTION
Table cells in two admin views, Text customization and URL redirects, are broken due to bootstrap column classes on `th` heading cells.

These classes do not work in this context.

![2021-01-13_08-45-40](https://user-images.githubusercontent.com/8503840/104416911-3dbcfa00-557d-11eb-99f7-db7886acd0e3.png)

Instead, when using Chrome, the only effect that is applied is `width: 100%;` which causes the first cell to be as wide as possible, and the rest as small as possible, which along with the `* { word-break: break-word; }` global style makes the cells one character wide.

![2021-01-13_08-42-03](https://user-images.githubusercontent.com/8503840/104417093-85438600-557d-11eb-8d9c-2e82b1233749.png)

Firefox seems to handle 100% width on all cells differently, and instead distributes the space evenly.