### PR TITLE
Fix admin redirects table data

### DIFF
--- a/client/app/views/admin/network/url_redirects.html
+++ b/client/app/views/admin/network/url_redirects.html
@@ -35,9 +35,9 @@
         </tr>
       </thead>
       <tbody>
-        <tr data-ng-repeat="redirect in resources.redirects | orderBy:'path2'" data-ng-controller="AdminRedirectEditCtrl">
+        <tr data-ng-repeat="redirect in resources.redirects | orderBy:'path1'" data-ng-controller="AdminRedirectEditCtrl">
+          <td>{{redirect.path1}}</td>
           <td>{{redirect.path2}}</td>
-          <td>{{redirect.path3}}</td>
           <td>
             <button class="btn btn-sm btn-danger"
                     data-ng-click="delete_redirect(redirect)">


### PR DESCRIPTION
This was changed from `path1` `path2` to `path2` `path3` in this commit https://github.com/globaleaks/GlobaLeaks/commit/10d4114b221b0ba518e185d717073ef5f53c8966#diff-0dc7bdfe6f435431b4fb5c703652258f46c11e8b11232850b3811ab96701890f

The effect is that "To" path ends up in "From" column in the table, and "To" column in the table is empty.