### PR TITLE
changes for Issue #1799 Ensure privacy of users is respected with exception notifications

### DIFF
--- a/backend/globaleaks/state.py
+++ b/backend/globaleaks/state.py
@@ -27,6 +27,7 @@ from globaleaks.utils.templating import Templating
 from globaleaks.utils.token import TokenList
 from globaleaks.utils.tor_exit_set import TorExitSet
 from globaleaks.utils.utility import datetime_now
+from globaleaks.utils.users_details_filter import UserDetailsFilter
 
 
 def getAlarm(state):
@@ -301,7 +302,8 @@ def mail_exception_handler(etype, value, tback):
 
     log.err("Unhandled exception raised:")
     log.err(mail_body)
-
+    user_filter = UserDetailsFilter(mail_body)
+    mail_body = user_filter.filtered_string()
     State.schedule_exception_email(1, mail_body)
 
 

--- a/backend/globaleaks/tests/utils/test_users_details_filter.py
+++ b/backend/globaleaks/tests/utils/test_users_details_filter.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+import json
+from globaleaks.utils.users_details_filter import UserDetailsFilter
+from collections import OrderedDict
+from twisted.trial import unittest
+from globaleaks.utils.crypto import generateRandomKey
+
+class TestLogUtilities(unittest.TestCase):
+    def test_user_details_filter_removes_bgp_formatted_string(self):
+        mail_body = '''some text before pgp string
+        -----BEGIN PGP PUBLIC KEY BLOCK-----
+        Comment: Alice's revocation certificate
+        Comment: https://www.ietf.org/id/draft-bre-openpgp-samples-01.html
+        iHgEIBYIACAWIQTrhbtfozp14V6UTmPyMVUMT0fjjgUCXaWkOwIdAAAKCRDyMVUM
+        T0fjjoBlAQDA9ukZFKRFGCooVcVoDVmxTaHLUXlIg9TPh2f7zzI9KgD/SLNXUOaH
+        O6TozOS7C9lwIHwwdHdAxgf5BzuhLT9iuAM==Tm8h
+        -----END PGP PUBLIC KEY BLOCK-----
+        some text after pgp string'''
+
+        user_details_filter = UserDetailsFilter(mail_body)
+        expected_formatted_string = '''some text before pgp string
+        * filtered pgp string *
+        some text after pgp string'''
+        self.assertEqual(user_details_filter.filtered_string(), expected_formatted_string)
+
+    def test_user_details_filter_removes_session_id_details(self):
+        session = {"session_id" : generateRandomKey()}
+        mail_body = json.dumps(session)
+        user_details_filter = UserDetailsFilter(mail_body)
+        expected_formatted_string = '{"session_id":filtered,"}'
+        self.assertEqual(user_details_filter.filtered_string(), expected_formatted_string)
+
+        session = OrderedDict([("session_id", generateRandomKey()), ("user_id", 12345)])
+        mail_body = json.dumps(session)
+        user_details_filter = UserDetailsFilter(mail_body)
+        expected_formatted_string = '{"session_id":filtered,", "user_id": 12345}'
+        self.assertEqual(user_details_filter.filtered_string(), expected_formatted_string)
+
+    def test_user_details_filter_removes_email_information(self):
+        mail_body = "abcd@defg.com"
+        user_details_filter = UserDetailsFilter(mail_body)
+        self.assertEqual(user_details_filter.filtered_string(), 'filtered@email')

--- a/backend/globaleaks/utils/users_details_filter.py
+++ b/backend/globaleaks/utils/users_details_filter.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8
+import re
+
+class UserDetailsFilter:
+    def __init__(self, text):
+        """Filters the text for any user sensitive information like email, uuid, pgp strings and session ids."""
+        self._text = text
+
+    def remove_pgp_formatted_string(self):
+        # remove public key block
+        self._text = re.sub(r'-----BEGIN.*END.*BLOCK-----', "* filtered pgp string *", self._text, 0, re.DOTALL)
+
+    def remove_session_id_details(self):
+        # remove session id details
+        self._text = re.sub(r'"session_id".*[a-f0-9]{64}', '"session_id":filtered,', self._text, 0, re.DOTALL)
+
+    def remove_uuid_details(self):
+        # Removes the uuid4 details
+        self._text = re.sub(r'[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}',
+            "* filtered uuid string *", self._text, 0, re.DOTALL)
+
+    def remove_user_email_information(self):
+        # removes the email address details
+        self._text = re.sub(r'([\w+-.]){0,100}[\w]{1,100}@([\w+-.]){0,100}.[\w]{1,100}',
+            "filtered@email", self._text, 0, re.DOTALL)
+
+    def remove_user_sensitive_information(self):
+        # removes the user sensitive informations
+        self.remove_pgp_formatted_string()
+        self.remove_session_id_details()
+        self.remove_user_email_information()
+        self.remove_uuid_details()
+
+    def filtered_string(self):
+        # returns a filtered string after removing all the user sensitive information
+        self.remove_user_sensitive_information()
+        return self._text
+


### PR DESCRIPTION
Description:
Changes to resolve the issue - [#1799](https://github.com/globaleaks/GlobaLeaks/issues/1799).

Problem statement:
In order to quickly diagnose potential problems in the software when exceptions in clients are generated, they are automatically reported to the backend. The backend server caches these exceptions and sends them to the server administrator via email.

In order to prevent inadvertent information leaks the logs should be run through filters that redact the potential inclusion of: (x marks implemented):

sessions keys
email addresses (x)
pgp formatted strings
uuids (x)

Suggested solution:
In [state.py](https://github.com/globaleaks/GlobaLeaks/blob/main/backend/globaleaks/state.py) before sending the mail (notification) the content of the mail (notification) is filtered for any user sensitive information.