### PR TITLE
Add location to $rootScope so it can activate menu items

### DIFF
--- a/client/app/js/app.js
+++ b/client/app/js/app.js
@@ -495,6 +495,7 @@ var GL = angular.module("GL", [
     $rootScope.fieldUtilities = fieldUtilities;
     $rootScope.AdminUtils = AdminUtils;
     $rootScope.CONSTANTS = CONSTANTS;
+    $rootScope.location = $location;
 
     $rootScope.showLoadingPanel = false;
 


### PR DESCRIPTION
I noticed that in the `sidebar.html` templates a call to location is being made in order to activate buttons. However, this fails and the nav links are not activated.
