### PR TITLE
Documentation/Docker: Fix Debian release detection

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,1 +1,1 @@
-requirements/requirements-bullseye.txt
+requirements/requirements-bookworm.txt

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:12-slim
 
 RUN apt-get update -q && \
-    apt-get install -y wget && \
+    apt-get install -y wget lsb-release && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,10 +146,10 @@ echo " + required TCP sockets open"
 #
 # Depending on the intention of the user to proceed anyhow installing on
 # a not supported distro we using the experimental package if it exists
-# or Buster as fallback.
+# or bookworm as fallback.
 if echo "$DISTRO_CODENAME" | grep -vqE "^(bionic|bookworm|bullseye|buster|focal|jammy)$"; then
-  # In case of unsupported platforms we fallback on Bullseye
-  echo "No packages available for the current distribution; the install script will use the Buster repository."
+  # In case of unsupported platforms we fallback on bookworm
+  echo "No packages available for the current distribution; the install script will use the bookworm repository."
   DISTRO="Debian"
   DISTRO_CODENAME="bookworm"
 fi


### PR DESCRIPTION
In install.sh, a comment (Buster) and a fixed output string (Bullseye) were inconsistent to the actual default (bookworm). Plus, in a Docker build using Debian 12-slim, the lsb_release command is not present, resulting in DISTRO_CODENAME to be 'unknown'. Fixed by installing the package lsb-release in Dockerfile before the install script is executed.

Before you submit a pull request, please make sure:

- [x] The pull request should include a description of the problem you're trying to solve
- [x] The pull request should include overview of the suggested solution
- [x] If the pull requests changes current behavior, reasons why your solution is better.
- [x] The proposed code should be fully functional
- [ ] The proposed code should contain tests relevant to prove is functionality
- [ ] The proposed tests should ensure significative code coverage
- [ ] All new and existing tests should pass
