### PR TITLE
Fix ignored version argument in install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -82,7 +82,7 @@ usage() {
   echo -e " -v install a specific software version"
 }
 
-while getopts "ynvh:" opt; do
+while getopts "ynv:h" opt; do
   case $opt in
     y) ASSUMEYES=1
     ;;


### PR DESCRIPTION
I was not able to install a specific version, because the version argument was ignored and always the lastest version got installed.

The colon was in the wrong place. Now the version argument will be respected and the specified version gets installed.

```bash
./install.sh -v 4.13.16
```

Before you submit a pull request, please make sure:

- [x] The pull request should include a description of the problem you're trying to solve
- [x] The pull request should include overview of the suggested solution
- [x] If the pull requests changes current behavior, reasons why your solution is better.
- [x] The proposed code should be fully functional
- [x] The proposed code should contain tests relevant to prove is functionality
- [x] The proposed tests should ensure significative code coverage
- [x] All new and existing tests should pass
