### PR TITLE
Fix #3794: Silence apparmor warnings for /usr/bin/uname

### DIFF
--- a/debian/apparmor/usr.bin.globaleaks
+++ b/debian/apparmor/usr.bin.globaleaks
@@ -49,7 +49,7 @@ profile usr.bin.globaleaks flags=(attach_disconnected) {
     owner /var/crash/** rwkl,
 
     # Explicit silent deny rules:
-    deny /bin/uname x,
+    deny /{,usr/}bin/uname x,
     deny /usr/bin/gcc-** x,
     deny /usr/bin/x86_64-linux-gnu-** x,
     deny /sbin/ldconfig x,


### PR DESCRIPTION
This PR should fix the aforementioned bug.

I've noticed some non-silenced AppArmor alerts for attempted execution of `uname`. In some systems, the preferred execution path is `/usr/bin/`, but in the project's profile, only `/bin/uname` is silenced.

I adjusted the profile to include both paths:
```
deny /{,usr/}bin/uname x,
```


Before you submit a pull request, please make sure:

- [x] The pull request should include a description of the problem you're trying to solve
- [x] The pull request should include overview of the suggested solution
- [ ] If the pull requests changes current behavior, reasons why your solution is better.
- [x] The proposed code should be fully functional
- [ ] The proposed code should contain tests relevant to prove is functionality
- [ ] The proposed tests should ensure significative code coverage
- [ ] All new and existing tests should pass
