### PR TITLE
fixed audio processing leak by closing the stream after processing

### DIFF
--- a/client/app/js/controllers/fileupload.js
+++ b/client/app/js/controllers/fileupload.js
@@ -43,6 +43,7 @@ controller("AudioUploadCtrl", ["$scope", "flowFactory", "Utils", "mediaProcessor
   let mediaRecorder = null;
   let flow = null;
   let secondsTracker = null;
+  let context;
 
   $scope.seconds = 0;
   $scope.activeButton = null;
@@ -145,7 +146,7 @@ controller("AudioUploadCtrl", ["$scope", "flowFactory", "Utils", "mediaProcessor
 
     await mediaProcessor.enableNoiseSuppression(stream);
 
-    var context = new AudioContext();
+    context = new AudioContext();
     var mediaStreamDestination = new MediaStreamAudioDestinationNode(context);
     const source = context.createMediaStreamSource(stream);
     const anonymization_filter = new anonymizeSpeaker(context);
@@ -192,6 +193,9 @@ controller("AudioUploadCtrl", ["$scope", "flowFactory", "Utils", "mediaProcessor
 
     if (mediaRecorder && (mediaRecorder.state === "recording" || mediaRecorder.state === "paused")) {
       mediaRecorder.stop();
+    }
+    if (context) {
+      context.close();
     }
   };
 


### PR DESCRIPTION
The issue with the AudioContext in fileupload.js was that it was not being closed properly when a recording exceeded the specified timeline. This led to unnecessary processing drain, especially when multiple audio recordings were involved.

To fix this, I ensured that the stream is closed after the specified time limit is exceeded, preventing any additional processing drain.

Closes #3999