### PR TITLE
Correct error handling for duplicate user error

### DIFF
--- a/backend/globaleaks/handlers/admin/user.py
+++ b/backend/globaleaks/handlers/admin/user.py
@@ -62,6 +62,10 @@ def db_create_user(session, tid, user_session, request, language):
     if not request['username']:
         user.username = user.id = uuid4()
 
+    existing_user = session.query(models.User).filter(models.User.tid == user.tid).first()
+    if existing_user:
+        raise errors.DuplicateUserError
+
     user.salt = GCE.generate_salt()
 
     user.language = request['language']

--- a/backend/globaleaks/rest/errors.py
+++ b/backend/globaleaks/rest/errors.py
@@ -182,3 +182,8 @@ class AccessLocationInvalid(GLException):
     reason = "IP Address not allows to login from this location"
     error_code = 16
     status_code = 401
+
+class DuplicateUserError(GLException):
+    reason = "A user with this username already exists"
+    error_code = 17
+    status_code = 422

--- a/client/app/views/partials/messageconsole.html
+++ b/client/app/views/partials/messageconsole.html
@@ -31,6 +31,10 @@
       <div data-ng-switch-when="14">
         <span data-translate>The upload request exceeds the size limit</span>
       </div>
+
+      <div data-ng-switch-when="17">
+        <span data-translate>A user with this username already exists</span>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
If sqlalchemy returns a specific error which indicates the user id already exists, then preform a rollback as the try/except clause stops this from happening before returning a more detailed error message.

Added this error into the list of errors in the client.

Resolves #3875 

Before you submit a pull request, please make sure:

- [x] The pull request should include a description of the problem you're trying to solve
- [x] The pull request should include overview of the suggested solution
- [ ] ~~If the pull requests changes current behavior, reasons why your solution is better.~~
- [x] The proposed code should be fully functional
- [ ] The proposed code should contain tests relevant to prove is functionality
- [ ] The proposed tests should ensure significative code coverage
- [ ] All new and existing tests should pass
