### PR TITLE
Update user.component.ts

### DIFF
--- a/client/app/src/shared/partials/header/template/user/user.component.ts
+++ b/client/app/src/shared/partials/header/template/user/user.component.ts
@@ -6,32 +6,40 @@ import {UtilsService} from "@app/shared/services/utils.service";
 import {AppDataService} from "@app/app-data.service";
 import {TranslationService} from "@app/services/helper/translation.service";
 import {HttpService} from "@app/shared/services/http.service";
-import {ActivatedRoute} from "@angular/router";
+import {ActivatedRoute, Router} from "@angular/router";
 
 @Component({
   selector: "views-user",
   templateUrl: "./user.component.html"
 })
 export class UserComponent {
+  private lastLang: string | null = null;
 
-  constructor(protected activatedRoute: ActivatedRoute, protected httpService: HttpService, protected appConfigService: AppConfigService, private cdr: ChangeDetectorRef, protected authentication: AuthenticationService, protected preferences: PreferenceResolver, protected utils: UtilsService, protected appDataService: AppDataService, protected translationService: TranslationService) {
+  constructor(protected activatedRoute: ActivatedRoute, protected httpService: HttpService, protected appConfigService: AppConfigService, private cdr: ChangeDetectorRef, protected authentication: AuthenticationService, protected preferences: PreferenceResolver, protected utils: UtilsService, protected appDataService: AppDataService, protected translationService: TranslationService, private router: Router) {
     this.onQueryParameterChangeListener();
   }
 
   onQueryParameterChangeListener() {
     this.activatedRoute.queryParams.subscribe(params => {
+      const currentLang = params['lang'];
+      const isSubmissionRoute = this.router.url.includes('/submission');
       const storageLanguage = localStorage.getItem("default_language");
-      if (params["lang"]) {
-        const paramLangValue = params["lang"] && this.appDataService.public.node.languages_enabled.includes(params["lang"]) ? params["lang"] : "";
-        if (paramLangValue) {
-          if (storageLanguage !== paramLangValue) {
-            this.translationService.onChange(paramLangValue);
-            this.appConfigService.reinit(false);
+      const languagesEnabled = this.appDataService.public.node.languages_enabled;
+
+      if (currentLang && languagesEnabled.includes(currentLang)) {
+        if (isSubmissionRoute && this.lastLang && this.lastLang !== currentLang) {
+          location.reload();
+        }
+        else if (storageLanguage !== currentLang) {
+          this.translationService.onChange(currentLang);
+          localStorage.setItem("default_language", currentLang);
+          if (!isSubmissionRoute) {
+            this.appConfigService.reinit(true);
             this.utils.reloadCurrentRouteFresh();
           }
-          localStorage.setItem("default_language", paramLangValue);
         }
       }
+      this.lastLang = currentLang;
     });
   }
 

--- a/client/cypress/e2e/14-test-admin-configure-custom-texts.cy.ts
+++ b/client/cypress/e2e/14-test-admin-configure-custom-texts.cy.ts
@@ -38,6 +38,7 @@ describe("admin configure custom texts", () => {
     cy.logout();
 
     cy.visit("/#/");
+    cy.reload();
     cy.get('#submissions_disabled').should('not.contain', 'Whistleblowing disabled');
   });
 });


### PR DESCRIPTION
Fix for Crash on Language Change During Submission:

1. Route Reloading on Language Change: We now explicitly reload the route when the language is changed while the user is on the submission page. Previously, navigating to the index page was blocked during a submission, leading to repeated reload requests that caused the crash.

2. Handling Other Routes: All other routes are functioning as expected. We've implemented a solution that reloads the components directly, rather than the entire route, enhancing performance and stability.