### PR TITLE
#4116:Display report expiration date changes

### DIFF
--- a/backend/globaleaks/handlers/whistleblower/wbtip.py
+++ b/backend/globaleaks/handlers/whistleblower/wbtip.py
@@ -198,6 +198,7 @@ class WBTipInstance(BaseHandler):
         if crypto_tip_prv_key:
             tip = yield deferToThread(decrypt_tip, self.session.cc, crypto_tip_prv_key, tip)
 
+            tip = yield serializers.process_logs(tip, tip['id'])
         returnValue(tip)
 
 

--- a/client/app/src/models/app/shared-public-model.ts
+++ b/client/app/src/models/app/shared-public-model.ts
@@ -133,6 +133,9 @@ export interface Comment {
   content: string;
   author_id: string;
   visibility: string;
+  is_audit_log?: boolean;
+  audit_log_type?: string;
+  data: any; // TODO: Find possible values for data and create a type for it.
 }
 
 export interface WbFile {

--- a/client/app/src/shared/partials/tip-comments/tip-comments.component.html
+++ b/client/app/src/shared/partials/tip-comments/tip-comments.component.html
@@ -1,5 +1,4 @@
 <div id="TipCommunicationComments" class="card card-default" [attr.aria-expanded]="collapsed">
-
     <div class="card-header d-flex justify-content-between" (click)="toggleCollapse(); utilsService.stopPropagation($event);">
         <span>{{'Comments'|translate}}</span>
         <span class="">
@@ -34,12 +33,17 @@
                         </span>
                         <br/>
                     </div>
-                    <div *ngIf="comment.author_id" class="message">
+                    <div *ngIf="comment.author_id && !comment.is_audit_log" class="message">
                         <div class="row">
                             <div class="col-md-6">{{tipService.tip.receivers_by_id[comment.author_id].name}}</div>
                             <div class="col-md-6 text-end">{{comment.creation_date | date:'dd-MM-yyyy HH:mm'}}</div>
                         </div>
                         <div class="preformatted">{{comment.content}}</div>
+                    </div>
+                    <div *ngIf="comment.is_audit_log" class="message">
+                        <div>{{'Author'|translate}}: {{tipService.tip.receivers_by_id[comment.author_id].name}}</div>
+                        <div>{{'Date'|translate}}: {{comment.creation_date | date:'MMM d, y, HH:mm:ss'}}</div>
+			            <div *ngIf="comment.audit_log_type == 'update_report_expiration'">{{'Expiration date'|translate}}: {{comment.data.curr_expiration_date | date:'MMM d, y'}}</div>
                     </div>
                 </div>
             </div>

--- a/client/app/src/shared/partials/tip-comments/tip-comments.component.ts
+++ b/client/app/src/shared/partials/tip-comments/tip-comments.component.ts
@@ -1,3 +1,4 @@
+import {AppDataService} from "@app/app-data.service";
 import {ChangeDetectorRef, Component, Input, OnInit} from "@angular/core";
 import {WbtipService} from "@app/services/helper/wbtip.service";
 import {AuthenticationService} from "@app/services/helper/authentication.service";
@@ -24,7 +25,7 @@ export class TipCommentsComponent implements OnInit {
   comments: Comment[] = [];
   newComments: Comment;
 
-  constructor(private maskService:MaskService,protected preferenceResolver:PreferenceResolver,private rTipService: ReceiverTipService, protected authenticationService: AuthenticationService, protected utilsService: UtilsService, private cdr: ChangeDetectorRef) {
+  constructor(private maskService:MaskService,protected preferenceResolver:PreferenceResolver,private rTipService: ReceiverTipService, protected authenticationService: AuthenticationService, protected utilsService: UtilsService, private cdr: ChangeDetectorRef, public appDataService: AppDataService) {
 
   }
 


### PR DESCRIPTION
Before you submit a pull request, please make sure:

- [x] The pull request should include a description of the problem you're trying to solve
- [x] The pull request should include overview of the suggested solution
- [x] If the pull requests changes current behavior, reasons why your solution is better.
- [x] The proposed code should be fully functional
- [ ] The proposed code should contain tests relevant to prove is functionality
- [ ] The proposed tests should ensure significative code coverage
- [ ] All new and existing tests should pass

See https://github.com/globaleaks/GlobaLeaks/issues/4116

### Steps to Test Locally:

1. Checkout this branch `feature/4116-display-report-expiration-changes`
2. Build client code: `cd client` && `./node_modules/grunt/bin/grunt build`
3. Start server: ``cd backend` && `bin/globaleaks -z -n`
4. Go to https://127.0.0.1:8443
5. Log into a recipient dashboard
6. Update a report expiration date
7. Confirm a new comment added to the report


### Screeshots:

![Screenshot from 2024-07-03 21-38-48](https://github.com/globaleaks/GlobaLeaks/assets/19332232/017cc712-9421-4b18-af34-83fc8041d6ab)
![Screenshot from 2024-07-03 21-38-59](https://github.com/globaleaks/GlobaLeaks/assets/19332232/9ba84afb-2c06-4688-844d-e5aaa13baca1)

### TODO:
Add these proposed API tests for these two endpoints:  `/api/recipient/rtips/{id}/comments` and `/api/whistleblower/wbtip/comments`.

1. Assert that a comment is added for every change in expiration date.
2. Assert that the comments are visible on both the recipient's and whistleblower's reports.
3. Assert that auditlog-related comments contain all the fields, including `is_audit_log` and `audit_log_type`.